### PR TITLE
fix(security): prevent symlink traversal in packet construction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,23 @@
+## 2026-01-19 - Symlink Traversal in Packet Construction
+
+**Vulnerability:** `ContentSelector::walk_directory` followed symlinks during recursive directory walking, allowing arbitrary file read (path traversal) if a malicious symlink was present in the source tree. This could expose sensitive system files to the LLM context packet.
+
+**Severity:** HIGH
+
+**Root Cause:** The original implementation used `path.is_dir()` which follows symlinks (stat behavior), and `fs::read_to_string()` which also follows symlinks. This meant:
+1. A symlink to `/etc/passwd` would be read and included in the packet
+2. A symlink to a directory outside the workspace would be recursively traversed
+
+**Learning:** `fs::read_dir` returns entries where `entry.file_type()` reflects the link itself (lstat semantics), but `path.is_dir()` and `path.is_file()` follow links (stat semantics). Recursive walkers must explicitly check `file_type.is_symlink()` to avoid unintended traversal. `fs::read_to_string` also follows links.
+
+**Fix Applied:**
+1. Check `file_type.is_symlink()` before processing any entry
+2. Default behavior: skip all symlinks (secure-by-default)
+3. Optional `allow_symlinks(true)`: validate symlink targets stay within the base directory using `fs::canonicalize()`
+4. Fail-closed: broken symlinks or canonicalization errors result in skipping the entry
+
+**Prevention:** Always check `is_symlink()` during directory traversal. Use `SandboxRoot` or equivalent canonicalization checks to ensure symlink targets stay within trust boundaries. Default to rejecting symlinks.
+
+**Files Changed:**
+- `crates/xchecker-engine/src/packet/selectors.rs` - Core fix in `walk_directory()`
+- `crates/xchecker-engine/src/packet/builder.rs` - API surface for configuration

--- a/crates/xchecker-engine/src/packet/builder.rs
+++ b/crates/xchecker-engine/src/packet/builder.rs
@@ -216,6 +216,20 @@ impl PacketBuilder {
         self.cache = None;
     }
 
+    /// Enable or disable symlink following for content selection.
+    ///
+    /// When enabled, symlinks are only followed if they resolve to paths
+    /// within the base directory being scanned (sandbox validation).
+    /// This prevents path traversal attacks.
+    ///
+    /// Default is `false` (symlinks are skipped for security).
+    #[must_use]
+    #[allow(dead_code)] // Builder configuration method
+    pub fn allow_symlinks(mut self, allow: bool) -> Self {
+        self.selector = self.selector.allow_symlinks(allow);
+        self
+    }
+
     /// Build a packet from the given base path and phase context
     /// Returns a Packet with content and evidence, or fails pre-Claude if budget exceeded
     pub fn build_packet(

--- a/crates/xchecker-engine/src/packet/selectors.rs
+++ b/crates/xchecker-engine/src/packet/selectors.rs
@@ -17,6 +17,12 @@ pub struct ContentSelector {
     exclude_patterns: GlobSet,
     /// Priority rules for content selection
     priority_rules: PriorityRules,
+    /// Whether to follow symlinks (default: false for security)
+    ///
+    /// When false (default), symlinks are skipped during directory traversal.
+    /// When true, symlinks are only followed if they resolve to paths within
+    /// the base directory (sandbox), preventing path traversal attacks.
+    allow_symlinks: bool,
 }
 
 impl ContentSelector {
@@ -50,7 +56,22 @@ impl ContentSelector {
             include_patterns: include_builder.build()?,
             exclude_patterns: exclude_builder.build()?,
             priority_rules: PriorityRules::default(),
+            allow_symlinks: false,
         })
+    }
+
+    /// Enable or disable symlink following during directory traversal.
+    ///
+    /// When enabled, symlinks are only followed if they resolve to paths
+    /// within the base directory being scanned (sandbox validation).
+    /// This prevents path traversal attacks while allowing legitimate
+    /// intra-directory symlinks.
+    ///
+    /// Default is `false` (symlinks are skipped).
+    #[must_use]
+    pub const fn allow_symlinks(mut self, allow: bool) -> Self {
+        self.allow_symlinks = allow;
+        self
     }
 
     /// Create a `ContentSelector` with custom patterns
@@ -71,6 +92,7 @@ impl ContentSelector {
             include_patterns: include_builder.build()?,
             exclude_patterns: exclude_builder.build()?,
             priority_rules: PriorityRules::default(),
+            allow_symlinks: false,
         })
     }
 
@@ -101,6 +123,7 @@ impl ContentSelector {
                     include_patterns: include_builder.build()?,
                     exclude_patterns: exclude_builder.build()?,
                     priority_rules: PriorityRules::default(),
+                    allow_symlinks: false,
                 })
             }
             None => Self::new(),
@@ -146,8 +169,8 @@ impl ContentSelector {
     pub fn select_files(&self, base_path: &Utf8Path) -> Result<Vec<SelectedFile>> {
         let mut files = Vec::new();
 
-        // Walk the directory tree
-        self.walk_directory(base_path, &mut files)?;
+        // Walk the directory tree, passing root for symlink sandbox validation
+        self.walk_directory(base_path, base_path, &mut files)?;
 
         // Sort by priority (Upstream first, then High, Medium, Low)
         // Within each priority, maintain LIFO order (reverse chronological)
@@ -164,8 +187,21 @@ impl ContentSelector {
         Ok(files)
     }
 
-    /// Recursively walk directory and collect matching files
-    fn walk_directory(&self, dir: &Utf8Path, files: &mut Vec<SelectedFile>) -> Result<()> {
+    /// Recursively walk directory and collect matching files.
+    ///
+    /// # Security
+    ///
+    /// This method implements symlink traversal protection:
+    /// - When `allow_symlinks` is false (default), symlinks are skipped entirely
+    /// - When `allow_symlinks` is true, symlinks are only followed if their
+    ///   canonical path is within the `root` directory (sandbox validation)
+    /// - Broken symlinks or canonicalization failures result in skipping (fail-closed)
+    fn walk_directory(
+        &self,
+        root: &Utf8Path,
+        dir: &Utf8Path,
+        files: &mut Vec<SelectedFile>,
+    ) -> Result<()> {
         if !dir.exists() {
             return Ok(());
         }
@@ -173,9 +209,33 @@ impl ContentSelector {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = Utf8PathBuf::try_from(entry.path()).context("Invalid UTF-8 path")?;
+            let file_type = entry.file_type()?;
 
+            // Security: Handle symlinks with sandbox validation
+            if file_type.is_symlink() {
+                if !self.allow_symlinks {
+                    // Secure default: skip all symlinks
+                    continue;
+                }
+
+                // Symlinks allowed: verify target stays within sandbox (root)
+                // Fail-closed: if canonicalization fails, skip the entry
+                let is_safe = match (fs::canonicalize(&path), fs::canonicalize(root)) {
+                    (Ok(canonical_path), Ok(canonical_root)) => {
+                        canonical_path.starts_with(&canonical_root)
+                    }
+                    _ => false, // Broken symlink or resolution error - skip
+                };
+
+                if !is_safe {
+                    // Symlink points outside sandbox or is broken - skip
+                    continue;
+                }
+            }
+
+            // Recurse into directories (including validated symlinked directories)
             if path.is_dir() {
-                self.walk_directory(&path, files)?;
+                self.walk_directory(root, &path, files)?;
             } else if self.should_include(&path) {
                 let priority = self.get_priority(&path);
                 let content = fs::read_to_string(&path)
@@ -354,5 +414,157 @@ mod tests {
         assert!(!selector.should_include(Utf8Path::new("src/main.rs")));
 
         Ok(())
+    }
+
+    // ===== Symlink Security Tests =====
+    //
+    // These tests verify the symlink traversal protection (CVE-style path traversal fix).
+    // Some tests are Unix-only because Windows symlinks require special permissions.
+
+    #[test]
+    fn test_allow_symlinks_defaults_to_false() -> Result<()> {
+        let selector = ContentSelector::new()?;
+        // The field is private, but we can verify behavior through selection
+        // Default should skip symlinks entirely
+        assert!(!selector.allow_symlinks);
+        Ok(())
+    }
+
+    #[test]
+    fn test_allow_symlinks_builder_method() -> Result<()> {
+        let selector = ContentSelector::new()?.allow_symlinks(true);
+        assert!(selector.allow_symlinks);
+
+        let selector2 = ContentSelector::new()?.allow_symlinks(false);
+        assert!(!selector2.allow_symlinks);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    mod symlink_tests {
+        use super::*;
+        use std::os::unix::fs::symlink;
+
+        #[test]
+        fn test_symlinks_skipped_by_default() -> Result<()> {
+            let temp_dir = TempDir::new()?;
+            let base_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())?;
+
+            // Create a real file
+            fs::write(base_path.join("real.md"), "# Real file")?;
+
+            // Create a symlink to the real file
+            symlink(base_path.join("real.md"), base_path.join("link.md"))?;
+
+            let selector = ContentSelector::new()?;
+            let files = selector.select_files(&base_path)?;
+
+            // Should only include the real file, not the symlink
+            assert_eq!(files.len(), 1);
+            assert!(files[0].path.as_str().contains("real.md"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_symlinks_followed_when_allowed_and_safe() -> Result<()> {
+            let temp_dir = TempDir::new()?;
+            let base_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())?;
+
+            // Create a subdirectory with a file
+            fs::create_dir_all(base_path.join("subdir"))?;
+            fs::write(base_path.join("subdir/target.md"), "# Target file")?;
+
+            // Create a symlink within the base directory pointing to the subdirectory file
+            symlink(
+                base_path.join("subdir/target.md"),
+                base_path.join("safe_link.md"),
+            )?;
+
+            let selector = ContentSelector::new()?.allow_symlinks(true);
+            let files = selector.select_files(&base_path)?;
+
+            // Should include both the real file and the safe symlink
+            assert_eq!(files.len(), 2);
+            let paths: Vec<_> = files.iter().map(|f| f.path.as_str()).collect();
+            assert!(paths.iter().any(|p| p.contains("target.md")));
+            assert!(paths.iter().any(|p| p.contains("safe_link.md")));
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_symlinks_outside_sandbox_rejected_even_when_allowed() -> Result<()> {
+            let temp_dir = TempDir::new()?;
+            let base_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())?;
+
+            // Create a symlink pointing outside the base directory (to /etc/passwd or similar)
+            // Using a safe target that exists on most Unix systems
+            let outside_target = if cfg!(target_os = "macos") {
+                "/etc/hosts"
+            } else {
+                "/etc/passwd"
+            };
+
+            if std::path::Path::new(outside_target).exists() {
+                symlink(outside_target, base_path.join("escape.md"))?;
+
+                let selector = ContentSelector::new()?.allow_symlinks(true);
+                let files = selector.select_files(&base_path)?;
+
+                // Should NOT include the symlink pointing outside
+                assert!(
+                    files.is_empty() || !files.iter().any(|f| f.path.as_str().contains("escape"))
+                );
+            }
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_broken_symlinks_safely_skipped() -> Result<()> {
+            let temp_dir = TempDir::new()?;
+            let base_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())?;
+
+            // Create a symlink to a non-existent target
+            symlink(
+                base_path.join("nonexistent.md"),
+                base_path.join("broken_link.md"),
+            )?;
+
+            // Create a real file too
+            fs::write(base_path.join("real.md"), "# Real file")?;
+
+            let selector = ContentSelector::new()?.allow_symlinks(true);
+            let files = selector.select_files(&base_path)?;
+
+            // Should only include the real file, broken symlink should be skipped
+            assert_eq!(files.len(), 1);
+            assert!(files[0].path.as_str().contains("real.md"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_symlink_directory_traversal_blocked() -> Result<()> {
+            let temp_dir = TempDir::new()?;
+            let base_path = Utf8PathBuf::try_from(temp_dir.path().to_path_buf())?;
+
+            // Create a separate directory outside the base
+            let outside_dir = TempDir::new()?;
+            let outside_path = Utf8PathBuf::try_from(outside_dir.path().to_path_buf())?;
+            fs::write(outside_path.join("secret.md"), "# Secret content")?;
+
+            // Create a symlink to the outside directory
+            symlink(&outside_path, base_path.join("escape_dir"))?;
+
+            let selector = ContentSelector::new()?.allow_symlinks(true);
+            let files = selector.select_files(&base_path)?;
+
+            // Should NOT include files from the outside directory via symlink
+            assert!(files.is_empty() || !files.iter().any(|f| f.content.contains("Secret")));
+
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a **HIGH severity** path traversal vulnerability where `ContentSelector::walk_directory` followed symlinks during recursive directory walking, potentially exposing sensitive system files (e.g., `/etc/passwd`) to the LLM context packet.

**This is a maintainer takeover of #77** — the original Jules PR targeted outdated file paths (`src/packet.rs`, `src/phases.rs`) that don't exist in the current codebase. This replacement implements the same security fix in the correct locations.

### Security Fix
- **Secure default**: Symlinks are now skipped entirely during directory traversal
- **Safe opt-in**: `allow_symlinks(true)` validates targets stay within the sandbox using `fs::canonicalize()`
- **Fail-closed**: Broken symlinks or canonicalization errors result in skipping the entry

---

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base ref | `main` @ `f41d506` |
| Head ref | `maint/pr-77-symlink-security-20260119` @ `45c2ddf` |
| Commits | 1 |
| Files changed | 3 |
| Insertions | +254 |
| Deletions | -5 |

**Start review here:**
1. `crates/xchecker-engine/src/packet/selectors.rs` — Core fix in `walk_directory()`
2. `crates/xchecker-engine/src/packet/builder.rs` — API surface for configuration
3. `.jules/sentinel.md` — Security documentation

### Blast Radius / Surface Area
| Boundary | Affected? |
|----------|-----------|
| Public API | Yes — adds `ContentSelector::allow_symlinks()` and `PacketBuilder::allow_symlinks()` |
| Protocol/IO | No |
| Config/flags | No (no new config wiring; secure default requires no configuration) |
| Persistence/schema | No |
| Concurrency | No |

### Hotspot / Churn Context
- `selectors.rs` is load-bearing for packet construction but not high-churn
- Changes are additive (new field, new method, enhanced `walk_directory`)

### Verification Receipts

**Commands run:**
```bash
cargo fmt --all -- --check    # PASS (after auto-fix)
cargo clippy --workspace --all-targets --all-features -- -D warnings    # PASS
cargo test -p xchecker-engine --lib    # 364 passed, 0 failed, 1 ignored
cargo test -p xchecker-engine --lib selectors    # 12 passed (includes new symlink tests)
```

**What wasn't run:**
- Full integration test suite (requires claude-stub binary)
- Unix-only symlink tests (running on Windows; tests are conditionally compiled with `#[cfg(unix)]`)
- Pre-existing failing test in `xchecker-llm` (`test_fallback_on_missing_api_key`) — unrelated to this change

### Risk + Rollback
| Risk Class | LOW |
|------------|-----|
| **Rationale** | Additive change with secure default; no breaking changes to existing behavior |
| **Rollback** | Revert commit; previous behavior was to follow symlinks unconditionally |

---

## Decision Log

### Why this approach?
1. **Secure-by-default**: The vulnerability exists because `path.is_dir()` follows symlinks. Rather than requiring configuration to be secure, the fix skips symlinks by default.

2. **Sandbox validation for opt-in**: When symlinks are explicitly allowed, we validate they resolve within the base directory using `fs::canonicalize()`. This prevents escape even with user opt-in.

3. **Fail-closed semantics**: Any error during canonicalization (broken symlink, permission denied, etc.) results in skipping the entry rather than potentially following an unsafe path.

### What the original Jules PR got wrong
- Targeted `src/packet.rs` and `src/phases.rs` which don't exist
- Actual code lives in `crates/xchecker-engine/src/packet/selectors.rs`
- The security concept was correct; the file locations were outdated

### What I explicitly didn't do
- **Config wiring for `allow_links`**: The Jules PR tried to wire an `allow_links` config option through phases. I skipped this because:
  - The config option doesn't exist in the current schema
  - The secure default (skip symlinks) is the right behavior for most users
  - Adding config wiring is a separate concern that can be done later if needed

---

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p xchecker-engine --lib` passes (364 tests)
- [x] New tests added for symlink security behavior
- [ ] Unix-only symlink tests should be verified on CI (Linux runner)

Supersedes #77