### PR TITLE
feat(doctor): add color-coded output to health check report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,6 +4137,7 @@ dependencies = [
  "blake3",
  "camino",
  "chrono",
+ "crossterm",
  "dunce",
  "fd-lock",
  "libc",

--- a/crates/xchecker-utils/Cargo.toml
+++ b/crates/xchecker-utils/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
 serde_yaml = { workspace = true }
+crossterm = { workspace = true }
 strum = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/xchecker-utils/src/logging.rs
+++ b/crates/xchecker-utils/src/logging.rs
@@ -952,35 +952,42 @@ impl Logger {
 /// Log doctor report to console (wires Doctor into logging)
 pub fn log_doctor_report(report: &crate::types::DoctorOutput) {
     use crate::types::CheckStatus;
+    use crossterm::style::{Attribute, Color, Stylize};
 
-    println!("=== xchecker Environment Health Check ===");
+    println!(
+        "{}",
+        "=== xchecker Environment Health Check ==="
+            .with(Color::Cyan)
+            .attribute(Attribute::Bold)
+    );
     println!();
 
     for check in &report.checks {
-        let status_symbol = match check.status {
-            CheckStatus::Pass => "✓",
-            CheckStatus::Warn => "⚠",
-            CheckStatus::Fail => "✗",
+        let (status_symbol, status_text, color) = match check.status {
+            CheckStatus::Pass => ("✓", "PASS", Color::Green),
+            CheckStatus::Warn => ("⚠", "WARN", Color::Yellow),
+            CheckStatus::Fail => ("✗", "FAIL", Color::Red),
         };
 
-        let status_text = match check.status {
-            CheckStatus::Pass => "PASS",
-            CheckStatus::Warn => "WARN",
-            CheckStatus::Fail => "FAIL",
-        };
-
-        println!("{} {} [{}]", status_symbol, check.name, status_text);
+        println!(
+            "{} {} [{}]",
+            status_symbol.with(color).attribute(Attribute::Bold),
+            check.name.clone().attribute(Attribute::Bold),
+            status_text.with(color).attribute(Attribute::Bold)
+        );
         println!("  {}", check.details);
         println!();
     }
 
+    let (overall_text, overall_color) = if report.ok {
+        ("✓ HEALTHY", Color::Green)
+    } else {
+        ("✗ ISSUES DETECTED", Color::Red)
+    };
+
     println!(
         "Overall status: {}",
-        if report.ok {
-            "✓ HEALTHY"
-        } else {
-            "✗ ISSUES DETECTED"
-        }
+        overall_text.with(overall_color).attribute(Attribute::Bold)
     );
 }
 


### PR DESCRIPTION
## Summary

Add terminal colors to the `xchecker doctor` command output for improved UX:
- Header styled in cyan bold
- Status indicators: green for PASS, yellow for WARN, red for FAIL
- Check names and status text styled bold
- Preserves text symbols (✓, ⚠, ✗) for colorblind accessibility

**Supersedes PR #67** - that PR was based on `src/logging.rs` which was moved to `crates/xchecker-utils/src/logging.rs` in PR #66. This replacement PR applies the same color improvements to the correct location.

---

## Change Shape

| Metric | Value |
|--------|-------|
| Base ref | `main` @ `f41d506` |
| Head ref | `maint/pr-67-doctor-colors-20260119` @ `55d88d1` |
| Files changed | 3 |
| Lines | +26 / -17 |
| Commits | 1 |

**Start review here:** `crates/xchecker-utils/src/logging.rs` (core change)

## Blast Radius

| Surface | Affected? |
|---------|-----------|
| Public API | No |
| Protocol/IO boundary | No (console output only) |
| Config/flags | No |
| Persistence/schema | No |
| Concurrency | No |

**Scope:** Console output formatting only. No behavioral changes to health checks.

## Hotspot / Churn Context

- `logging.rs` was recently moved as part of workspace refactor (#66) - this is a clean addition to settled code
- `Cargo.toml` change adds workspace dependency that was already defined but unused in this crate

## Verification Receipts

| Command | Outcome |
|---------|---------|
| `cargo fmt --all -- --check` | PASS (no changes needed) |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | PASS (0 warnings) |
| `cargo test --workspace --lib --bins` | PASS (373 tests passed) |

**Not run:** Integration tests requiring claude-stub (out of scope for console output change)

## Risk + Rollback

**Risk class:** Low
- Output-only change with no side effects on core functionality
- crossterm is already a workspace dependency (used by TUI)

**Rollback:** Revert this commit or remove the crossterm styling calls

## Decision Log

1. **Why manual apply vs cherry-pick?** The original PR #67 targeted `src/logging.rs` which was moved to `crates/xchecker-utils/src/logging.rs` in #66. Cherry-pick produced conflicts due to the file path difference and import changes (`crate::doctor::CheckStatus` → `crate::types::CheckStatus`). Manual application was cleaner.

2. **Why add crossterm to xchecker-utils?** The dependency was already in the workspace but not wired to this crate. Adding it here keeps the doctor output styling self-contained in the logging module.

3. **Preserved from PR #67:** Color scheme (green/yellow/red), bold styling, cyan header, accessibility consideration (symbols preserved).