### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing OpenRouter and Resend key redaction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Missing Redaction for Supported Providers
+**Vulnerability:** OpenRouter and Resend API keys were not being redacted, despite OpenRouter being a supported LLM provider in the documentation.
+**Learning:** Adding support for a new provider (in code or docs) must be accompanied by adding its secret patterns to the redaction system. The system uses an allowlist of regex patterns, so it doesn't automatically detect new key formats.
+**Prevention:** When adding new providers or integrating with new services, always check `crates/xchecker-redaction/src/lib.rs` and add relevant patterns. Use `cargo run --features dev-tools --bin regenerate_secret_patterns_docs` to keep docs in sync.

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -172,6 +172,12 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "Anthropic API keys",
     },
     SecretPatternDef {
+        id: "openrouter_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"sk-or-v1-[A-Za-z0-9]{32,}",
+        description: "OpenRouter API keys",
+    },
+    SecretPatternDef {
         id: "openai_api_key",
         category: "LLM Provider Tokens",
         regex: r"sk-(?:proj|org)-[A-Za-z0-9_-]{20,}",
@@ -317,6 +323,12 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         category: "Platform-Specific Tokens",
         regex: r"SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}",
         description: "SendGrid API keys",
+    },
+    SecretPatternDef {
+        id: "resend_api_key",
+        category: "Platform-Specific Tokens",
+        regex: r"re_[A-Za-z0-9]{24,}",
+        description: "Resend API keys",
     },
     SecretPatternDef {
         id: "npm_token",

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **47 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,7 +70,7 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
@@ -78,8 +78,9 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |
+| `openrouter_api_key` | `sk-or-v1-[A-Za-z0-9]{32,}` | OpenRouter API keys |
 
-#### Platform-Specific Tokens (13 patterns)
+#### Platform-Specific Tokens (14 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
@@ -92,6 +93,7 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `npm_token` | `npm_[A-Za-z0-9]{36}` | NPM authentication tokens |
 | `nuget_key` | `(?i)nuget_?(?:api_?)?key[=:][A-Za-z0-9]{46}` | NuGet API keys |
 | `pypi_token` | `pypi-[A-Za-z0-9_-]{50,}` | PyPI API tokens |
+| `resend_api_key` | `re_[A-Za-z0-9]{24,}` | Resend API keys |
 | `sendgrid_key` | `SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}` | SendGrid API keys |
 | `slack_token` | `xox[baprs]-[A-Za-z0-9-]+` | Slack bot/user tokens |
 | `stripe_key` | `sk_(?:live\|test)_[A-Za-z0-9]{24,}` | Stripe API keys |


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add redaction for OpenRouter and Resend API keys

🚨 **Severity:** HIGH
💡 **Vulnerability:** OpenRouter keys (for a supported provider) and Resend keys were not being redacted from context sent to LLMs or logs.
🎯 **Impact:** If a user includes their `.env` file or config containing these keys in the context, the keys could be leaked to the LLM provider or logged in plain text.
🔧 **Fix:** Added regex patterns for `sk-or-v1-` (OpenRouter) and `re_` (Resend) to `crates/xchecker-redaction/src/lib.rs`.
✅ **Verification:** Verified with a reproduction test case that successfully detected both key types. Also ran `doc_validation` tests to ensure `SECURITY.md` is in sync.

---
*PR created automatically by Jules for task [12961849981466602781](https://jules.google.com/task/12961849981466602781) started by @EffortlessSteven*