### PR TITLE
🎨 Palette: Enhance TUI footer and add page navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-17 - TUI Footer Styling
+**Learning:** `ratatui` widgets like `Paragraph` accept `Line::from(vec![Span])` for rich styling, which is superior to plain strings for key bindings (e.g., cyan/bold for keys, dark gray for descriptions).
+**Action:** Always use structured Spans for TUI help text to improve scannability.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -244,6 +244,25 @@ impl TuiApp {
         }
     }
 
+    /// Move selection page up (10 items)
+    fn select_page_up(&mut self) {
+        if self.spec_statuses.is_empty() {
+            return;
+        }
+        self.selected_index = self.selected_index.saturating_sub(10);
+        self.list_state.select(Some(self.selected_index));
+    }
+
+    /// Move selection page down (10 items)
+    fn select_page_down(&mut self) {
+        if self.spec_statuses.is_empty() {
+            return;
+        }
+        let last_index = self.spec_statuses.len() - 1;
+        self.selected_index = (self.selected_index + 10).min(last_index);
+        self.list_state.select(Some(self.selected_index));
+    }
+
     /// Move selection down
     fn select_next(&mut self) {
         if self.spec_statuses.is_empty() {
@@ -325,6 +344,16 @@ where
                 KeyCode::End => {
                     if !app.show_details {
                         app.select_last();
+                    }
+                }
+                KeyCode::PageUp => {
+                    if !app.show_details {
+                        app.select_page_up();
+                    }
+                }
+                KeyCode::PageDown => {
+                    if !app.show_details {
+                        app.select_page_down();
                     }
                 }
                 KeyCode::Enter => app.toggle_details(),
@@ -677,13 +706,29 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
 
 /// Render the footer with help text
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let help_text = if app.show_details {
-        "Esc: Back  q: Quit"
+    let help = if app.show_details {
+        vec![
+            Span::styled("Esc", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Back  "),
+            Span::styled("q", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Quit"),
+        ]
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        vec![
+            Span::styled("↑/k", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Up  "),
+            Span::styled("↓/j", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Down  "),
+            Span::styled("PgUp/Dn", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Page  "),
+            Span::styled("Enter", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Details  "),
+            Span::styled("q", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(": Quit"),
+        ]
     };
 
-    let footer = Paragraph::new(help_text)
+    let footer = Paragraph::new(Line::from(help))
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
@@ -876,6 +921,58 @@ mod tests {
         app.select_next();
         assert_eq!(app.selected_index, 1);
         app.select_first();
+        assert_eq!(app.selected_index, 0);
+    }
+
+    #[test]
+    fn test_tui_app_paging() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path().join("workspace.yaml");
+        let mut workspace = Workspace::new("test-project");
+
+        // Create 25 specs
+        for i in 0..25 {
+            workspace
+                .add_spec(&format!("spec-{}", i), vec![], false)
+                .unwrap();
+        }
+        workspace.save(&workspace_path).unwrap();
+
+        let mut app = TuiApp::new(&workspace_path).unwrap();
+
+        // Start at 0
+        assert_eq!(app.selected_index, 0);
+
+        // Page Down -> 10
+        app.select_page_down();
+        assert_eq!(app.selected_index, 10);
+
+        // Page Down -> 20
+        app.select_page_down();
+        assert_eq!(app.selected_index, 20);
+
+        // Page Down -> 24 (last item)
+        app.select_page_down();
+        assert_eq!(app.selected_index, 24);
+
+        // Page Down again -> 24 (clamped)
+        app.select_page_down();
+        assert_eq!(app.selected_index, 24);
+
+        // Page Up -> 14
+        app.select_page_up();
+        assert_eq!(app.selected_index, 14);
+
+        // Page Up -> 4
+        app.select_page_up();
+        assert_eq!(app.selected_index, 4);
+
+        // Page Up -> 0
+        app.select_page_up();
+        assert_eq!(app.selected_index, 0);
+
+        // Page Up again -> 0 (clamped)
+        app.select_page_up();
         assert_eq!(app.selected_index, 0);
     }
 }


### PR DESCRIPTION
💡 What: Enhanced the TUI footer with styled keys and added PageUp/PageDown navigation.
🎯 Why: Improves readability of shortcuts and allows faster navigation in long lists.
📸 Before: Plain text footer, arrow keys only.
📸 After: Cyan/Bold keys in footer, PageUp/PageDown works.
♿ Accessibility: Better keyboard navigation efficiency and visual hierarchy.


---
*PR created automatically by Jules for task [1732198780513370723](https://jules.google.com/task/1732198780513370723) started by @EffortlessSteven*