### PR TITLE
🎨 Palette: Enhance TUI footer keyboard shortcut visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-17 - TUI Keyboard Shortcuts Styling
+**Learning:** Highlighting keyboard shortcuts (e.g., "Esc", "q") with a distinct color (Cyan/Bold) significantly improves scannability in TUI footer help text compared to plain text.
+**Action:** Apply this pattern to all TUI help footers and command prompts.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -677,13 +677,57 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
 
 /// Render the footer with help text
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let help_text = if app.show_details {
-        "Esc: Back  q: Quit"
+    let help_line = if app.show_details {
+        Line::from(vec![
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": Back  "),
+            Span::styled(
+                "q",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": Quit"),
+        ])
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        Line::from(vec![
+            Span::styled(
+                "↑/k",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": Up  "),
+            Span::styled(
+                "↓/j",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": Down  "),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": Details  "),
+            Span::styled(
+                "q",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(": Quit"),
+        ])
     };
 
-    let footer = Paragraph::new(help_text)
+    let footer = Paragraph::new(help_line)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What: The TUI footer help text now highlights keyboard shortcuts in Cyan/Bold, while keeping descriptions in DarkGray.
🎯 Why: To make keyboard shortcuts easier to scan and identify for users, improving accessibility and usability.
📸 Before: Plain gray text for the entire footer.
📸 After: Keys like "Esc" and "q" pop out visually.
♿ Accessibility: Improved visual hierarchy and readability for keyboard navigation hints.

---
*PR created automatically by Jules for task [10353090617516742672](https://jules.google.com/task/10353090617516742672) started by @EffortlessSteven*