### PR TITLE
🎨 Palette: Improve TUI footer help text visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2025-05-15 - TUI Footer Enhancement
+**Learning:** In terminal UIs, users scan for keybindings. Plain text footers are often ignored. Using distinct colors (Cyan) and weight (Bold) for keys vs descriptions significantly improves discoverability without adding clutter.
+**Action:** Always style keybindings in help text with high contrast against descriptions.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -677,14 +677,32 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
 
 /// Render the footer with help text
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let help_text = if app.show_details {
-        "Esc: Back  q: Quit"
+    let key_style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let desc_style = Style::default().fg(Color::DarkGray);
+
+    let spans = if app.show_details {
+        vec![
+            Span::styled("Esc", key_style),
+            Span::styled(": Back  ", desc_style),
+            Span::styled("q", key_style),
+            Span::styled(": Quit", desc_style),
+        ]
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        vec![
+            Span::styled("↑/k", key_style),
+            Span::styled(": Up  ", desc_style),
+            Span::styled("↓/j", key_style),
+            Span::styled(": Down  ", desc_style),
+            Span::styled("Enter", key_style),
+            Span::styled(": Details  ", desc_style),
+            Span::styled("q", key_style),
+            Span::styled(": Quit", desc_style),
+        ]
     };
 
-    let footer = Paragraph::new(help_text)
-        .style(Style::default().fg(Color::DarkGray))
+    let footer = Paragraph::new(Line::from(spans))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 **What:** Enhanced the TUI footer help text by styling keyboard shortcuts (Cyan, Bold) differently from their descriptions (DarkGray).
🎯 **Why:** To improve the scanability and discoverability of keybindings for users. Plain text footers are often overlooked or hard to parse quickly.
📸 **Before:** Plain text `↑/k: Up  ↓/j: Down ...`
📸 **After:** `[↑/k] Up  [↓/j] Down ...` (with colors)
♿ **Accessibility:** Improved visual hierarchy and contrast for better readability.


---
*PR created automatically by Jules for task [15596614975675879721](https://jules.google.com/task/15596614975675879721) started by @EffortlessSteven*