### PR TITLE
🎨 Palette: Improve visual hierarchy of TUI secondary states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-10 - TUI Visual Hierarchy for Secondary Empty States and Footers
+**Learning:** Secondary non-actionable elements (like "No spec selected" details pane or help footers) need distinct visual styling from primary actionable states to reduce cognitive load. Default left-aligned white text blends in with content.
+**Action:** Use `Alignment::Center` and `Color::DarkGray` for secondary empty states and footers in TUI applications to establish clear visual hierarchy.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -542,6 +542,8 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
         Some(s) => s,
         None => {
             let empty = Paragraph::new("No spec selected")
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(Alignment::Center)
                 .block(Block::default().borders(Borders::ALL).title(" Details "));
             f.render_widget(empty, area);
             return;
@@ -685,6 +687,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 **What:** Added `Alignment::Center` and `Color::DarkGray` to the "No spec selected" secondary empty state and the help footer in the TUI.
🎯 **Why:** To visually distinguish non-actionable secondary components from primary interactive lists, reducing user cognitive load. Left-aligned white text was blending in with core content.
♿ **Accessibility:** Reduces visual clutter and clarifies the visual hierarchy for users navigating the TUI.

---
*PR created automatically by Jules for task [10249662726879754600](https://jules.google.com/task/10249662726879754600) started by @EffortlessSteven*