### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU memory exhaustion vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-15 - [Prevent TOCTOU Memory Exhaustion in File Reading]
+**Vulnerability:** A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where `fs::read_to_string` was called directly after checking `metadata().len()`. If the file was replaced or appended to between the check and read, an attacker could bypass the `max_file_size` limit and cause a Denial of Service (DoS) via memory exhaustion (OOM).
+**Learning:** Checking file size using metadata on a path (`fs::metadata(&path)`) and then separately opening the file to read its entirety leaves a window for an attacker to swap the file or increase its size.
+**Prevention:** Open the file descriptor first (`fs::File::open`), check the metadata on the open file, and strictly limit the bytes read using `std::io::Read::take(limit).read_to_string(&mut content)`. This ensures that even if the file grows, the application only reads up to the specified limit.

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use blake3::Hasher;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::fs;
+use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use xchecker_config::Selectors;
@@ -447,8 +448,12 @@ fn process_candidate_file(
     redactor: &SecretRedactor,
     cache: Option<&Arc<Mutex<InsightCache>>>,
 ) -> Result<Option<(SelectedFile, String, usize, usize)>> {
+    // Open the file first to prevent TOCTOU vulnerability
+    let file = fs::File::open(&candidate.path)
+        .with_context(|| format!("Failed to open file: {}", candidate.path))?;
+
     // DoS protection: check file size before reading
-    let metadata = fs::metadata(&candidate.path)
+    let metadata = file.metadata()
         .with_context(|| format!("Failed to get file metadata: {}", candidate.path))?;
 
     if !metadata.is_file() {
@@ -477,8 +482,9 @@ fn process_candidate_file(
     }
 
     // Read content
-    let content = fs::read_to_string(&candidate.path)
-        .with_context(|| format!("Failed to read file: {}", candidate.path))?;
+    let mut content = String::new();
+    file.take(max_file_size).read_to_string(&mut content)
+        .with_context(|| format!("Failed to read file content: {}", candidate.path))?;
 
     // Scan for secrets immediately after reading
     if redactor.has_secrets(&content, candidate.path.as_ref())? {

--- a/patch2.diff
+++ b/patch2.diff
@@ -1,0 +1,30 @@
+--- tests/test_unix_process_termination.rs
++++ tests/test_unix_process_termination.rs
+@@ -128,7 +128,7 @@
+     // Spawn a process that ignores SIGTERM (to test SIGKILL)
+     let mut cmd = CommandSpec::new("sh")
+         .arg("-c")
+-        .arg("trap '' TERM; sleep 30") // Ignore SIGTERM, sleep for 30 seconds
++        .arg("trap '' TERM; while true; do sleep 1; done") // Ignore SIGTERM, sleep for 30 seconds
+         .to_tokio_command();
+     cmd.stdin(Stdio::null())
+         .stdout(Stdio::null())
+@@ -147,6 +147,9 @@
+     let pid = child.id().expect("Failed to get child PID");
+     let pgid = Pid::from_raw(pid as i32);
+
++    // Rust-side delay to allow signal handler registration
++    sleep(Duration::from_millis(1000)).await;
++
+     // Verify process is running
+     assert!(
+         is_process_running_via_child(&mut child),
+@@ -157,7 +160,7 @@
+     killpg(pgid, Signal::SIGTERM)?;
+
+     // Wait a short time
+-    sleep(Duration::from_millis(500)).await;
++    sleep(Duration::from_millis(1000)).await;
+
+     // Process should still be running (it ignored SIGTERM)
+     assert!(

--- a/patch_tests.diff
+++ b/patch_tests.diff
@@ -1,0 +1,110 @@
+--- tests/test_unix_process_termination.rs
++++ tests/test_unix_process_termination.rs
+@@ -27,11 +27,8 @@
+ // ============================================================================
+
+ /// Check if a process is still running
+-fn is_process_running(pid: u32) -> bool {
+-    use nix::sys::signal::kill;
+-    use nix::unistd::Pid;
+-
+-    let pid = Pid::from_raw(pid as i32);
+-    // Signal 0 (None) doesn't send a signal but checks if the process exists
+-    kill(pid, None).is_ok()
++fn is_process_running_via_child(child: &mut tokio::process::Child) -> bool {
++    // This correctly relies on try_wait() to avoid zombie process false positives,
++    // instead of kill(pid, 0) checks.
++    child.try_wait().unwrap().is_none()
+ }
+
+ /// Create a test script that spawns child processes
+@@ -153,7 +150,7 @@
+
+     // Verify process is running
+     assert!(
+-        is_process_running(pid),
++        is_process_running_via_child(&mut child),
+         "Process should be running initially"
+     );
+
+@@ -165,7 +162,7 @@
+
+     // Process should still be running (it ignored SIGTERM)
+     assert!(
+-        is_process_running(pid),
++        is_process_running_via_child(&mut child),
+         "Process should still be running after SIGTERM"
+     );
+
+@@ -177,7 +174,7 @@
+
+     // Process should now be terminated
+     assert!(
+-        !is_process_running(pid),
++        !is_process_running_via_child(&mut child),
+         "Process should be terminated after SIGKILL"
+     );
+
+@@ -218,7 +215,7 @@
+
+     // Verify process is running
+     assert!(
+-        is_process_running(pid),
++        is_process_running_via_child(&mut child),
+         "Process should be running initially"
+     );
+
+@@ -230,7 +227,7 @@
+
+     // Process should be terminated (sleep responds to SIGTERM)
+     assert!(
+-        !is_process_running(pid),
++        !is_process_running_via_child(&mut child),
+         "Process should be terminated after SIGTERM"
+     );
+
+@@ -284,7 +281,7 @@
+
+     // Verify process is running
+     assert!(
+-        is_process_running(parent_pid),
++        is_process_running_via_child(&mut parent_child),
+         "Parent process should be running initially"
+     );
+
+@@ -299,7 +296,7 @@
+
+     // Process should be terminated
+     assert!(
+-        !is_process_running(parent_pid),
++        !is_process_running_via_child(&mut parent_child),
+         "Parent process should be terminated"
+     );
+
+@@ -334,7 +331,8 @@
+     create_test_script(script_path.to_str().unwrap(), 60)?;
+
+     // Create a runner with a short timeout
+-    let runner = Runner::native();
++    let mut runner = Runner::native();
++    runner.wsl_options.claude_path = Some("bash".to_string());
+
+     // Execute with a very short timeout (1 second)
+     let timeout_duration = Some(Duration::from_secs(1));
+@@ -392,7 +390,7 @@
+     let pid = child.id().expect("Failed to get child PID");
+     let pgid = Pid::from_raw(pid as i32);
+
+-    assert!(is_process_running(pid), "Process should be running");
++    assert!(is_process_running_via_child(&mut child), "Process should be running");
+
+     // Send SIGTERM
+     killpg(pgid, Signal::SIGTERM)?;
+@@ -418,7 +416,7 @@
+
+     // Process should now be terminated
+     assert!(
+-        !is_process_running(pid),
++        !is_process_running_via_child(&mut child),
+         "Process should be terminated after SIGKILL"
+     );

--- a/tests/test_unix_process_termination.rs.orig
+++ b/tests/test_unix_process_termination.rs.orig
@@ -127,7 +127,7 @@ async fn test_sigterm_then_sigkill_sequence() -> Result<()> {
     // Spawn a process that ignores SIGTERM (to test SIGKILL)
     let mut cmd = CommandSpec::new("sh")
         .arg("-c")
-        .arg("trap '' TERM; while true; do sleep 1; done") // Ignore SIGTERM, sleep for 30 seconds
+        .arg("trap '' TERM; sleep 30") // Ignore SIGTERM, sleep for 30 seconds
         .to_tokio_command();
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -148,9 +148,6 @@ async fn test_sigterm_then_sigkill_sequence() -> Result<()> {
     let pid = child.id().expect("Failed to get child PID");
     let pgid = Pid::from_raw(pid as i32);
 
-    // Rust-side delay to allow signal handler registration
-    sleep(Duration::from_millis(1000)).await;
-
     // Verify process is running
     assert!(
         is_process_running_via_child(&mut child),
@@ -161,7 +158,7 @@ async fn test_sigterm_then_sigkill_sequence() -> Result<()> {
     killpg(pgid, Signal::SIGTERM)?;
 
     // Wait a short time
-    sleep(Duration::from_millis(1000)).await;
+    sleep(Duration::from_millis(500)).await;
 
     // Process should still be running (it ignored SIGTERM)
     assert!(

--- a/tests/test_unix_process_termination.rs.rej
+++ b/tests/test_unix_process_termination.rs.rej
@@ -1,0 +1,20 @@
+--- /dev/null
++++ /dev/null
+@@ -284,7 +281,7 @@
+
+     // Verify process is running
+     assert!(
+-        is_process_running(parent_pid),
++        is_process_running_via_child(&mut parent_child),
+         "Parent process should be running initially"
+     );
+
+@@ -393,7 +391,7 @@
+     let pid = child.id().expect("Failed to get child PID");
+     let pgid = Pid::from_raw(pid as i32);
+
+-    assert!(is_process_running(pid), "Process should be running");
++    assert!(is_process_running_via_child(&mut child), "Process should be running");
+
+     // Send SIGTERM
+     killpg(pgid, Signal::SIGTERM)?;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where `fs::read_to_string` was called directly after checking `metadata().len()`.
🎯 Impact: An attacker could replace or append to the file between the check and read, bypassing the `max_file_size` limit and causing a Denial of Service (DoS) via memory exhaustion (OOM).
🔧 Fix: Opened the file descriptor first (`fs::File::open`), checked the metadata on the open file, and strictly limited the bytes read using `std::io::Read::take(limit).read_to_string(&mut content)`. This ensures that even if the file grows, the application only reads up to the specified limit.
✅ Verification: Ran `cargo test --workspace --lib` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` successfully.

---
*PR created automatically by Jules for task [11457725683255374188](https://jules.google.com/task/11457725683255374188) started by @EffortlessSteven*