### PR TITLE
🎨 Palette: Center TUI empty states and footers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-21 - Distinct Visual Hierarchy for TUI Empty States and Footers
+**Learning:** In terminal user interfaces, secondary empty states (like details panels without selection) and help footers need clear visual distinction from actionable primary lists to avoid confusing users about where focus and action lie.
+**Action:** Use `Alignment::Center` and `Color::DarkGray` to style secondary non-actionable components, pushing them down the visual hierarchy.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -542,6 +542,8 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
         Some(s) => s,
         None => {
             let empty = Paragraph::new("No spec selected")
+                .style(Style::default().fg(Color::DarkGray))
+                .alignment(Alignment::Center)
                 .block(Block::default().borders(Borders::ALL).title(" Details "));
             f.render_widget(empty, area);
             return;
@@ -685,6 +687,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 **What:** Added center alignment and `Color::DarkGray` to the "No spec selected" empty state in the details view, and center alignment to the help text footer.
🎯 **Why:** To create a clear visual hierarchy. Secondary empty states and footers should be visually distinct from primary, actionable list items. Centering and dimming them pushes them down the visual hierarchy so they don't distract from the core interactive elements.
♿ **Accessibility:** Improves cognitive accessibility by clearly distinguishing interactive vs. non-interactive/supplementary components.

---
*PR created automatically by Jules for task [843966898285208485](https://jules.google.com/task/843966898285208485) started by @EffortlessSteven*