### PR TITLE
🎨 Palette: Center-align TUI help footers and empty states

### DIFF
--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -542,7 +542,9 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
         Some(s) => s,
         None => {
             let empty = Paragraph::new("No spec selected")
-                .block(Block::default().borders(Borders::ALL).title(" Details "));
+                .block(Block::default().borders(Borders::ALL).title(" Details "))
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::DarkGray));
             f.render_widget(empty, area);
             return;
         }
@@ -685,6 +687,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 **What**: Added center alignment to the TUI help footer and center-alignment with `DarkGray` styling to the "No spec selected" secondary empty state in the details view.

🎯 **Why**: 
- The footer help text is a global navigational aid; centering it creates better visual balance across the layout.
- The "No spec selected" text acts as a placeholder when no spec is actively viewed. Dimming it and centering it creates a distinct visual hierarchy that separates it from actual data content, making the interface feel more polished and intentional.

♿ **Accessibility**: Reduced visual clutter by making the empty state recede into the background, allowing users to focus on primary content (like the specs list) when no details are selected.

---
*PR created automatically by Jules for task [12251744244167912094](https://jules.google.com/task/12251744244167912094) started by @EffortlessSteven*