### PR TITLE
🎨 Palette: Center-align TUI help footer and add Home/End hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-24 - Center-align TUI help footer
+**Learning:** TUI help footers should be center-aligned to establish a clear visual hierarchy distinct from core content. Adding `Home/End: Top/Bottom` improves keyboard navigation discoverability.
+**Action:** Always center-align help text in TUI footers and ensure all available keyboard shortcuts are documented.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,10 +680,11 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 **What:**
- Center-aligned the `help_text` inside the `Paragraph` widget in `crates/xchecker-tui/src/lib.rs`.
- Added explicit documentation for the `Home/End` keyboard shortcuts to the footer text.
- Logged a critical UX learning in `.jules/palette.md` regarding footer alignments and documentation.

🎯 **Why:**
Help footers shouldn't visually blend into the primary content or standard lists. By centering the text, we establish a distinct visual boundary. Furthermore, while the TUI supports `Home` and `End` navigation, it wasn't explicitly mentioned, reducing discoverability for keyboard-focused users. 

♿ **Accessibility:**
- Improved keyboard navigation discoverability by explicitly stating available keyboard shortcuts (Home/End) on-screen.

---
*PR created automatically by Jules for task [5999603706568343447](https://jules.google.com/task/5999603706568343447) started by @EffortlessSteven*