### PR TITLE
🎨 Palette: [UX improvement] Center TUI help footer and document Home/End keys

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Center TUI Help Footer]
+**Learning:** TUI help footers without center alignment and complete shortcut lists lack visual hierarchy and discoverability.
+**Action:** Center-align help footers using Alignment::Center and explicitly document all available keyboard shortcuts.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,11 +680,12 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 **What:** Added center-alignment (`Alignment::Center`) to the TUI workspace help footer (`crates/xchecker-tui/src/lib.rs`) and updated the help text to explicitly document the `Home/End` navigation keyboard shortcuts.

🎯 **Why:** TUI interfaces rely heavily on text for guidance. Without explicit center alignment, the help footer text lacked visual hierarchy, blending with the primary content. Additionally, although `Home` and `End` keys were supported by the event loop, they were hidden from users. This micro-UX change makes navigation discoverability far more intuitive without changing core logic.

📸 **Before/After:** Not applicable (terminal interface text change).

♿ **Accessibility:** Improves keyboard navigation discoverability by explicitly documenting the `Home` and `End` shortcuts for immediate access to top/bottom items.

---
*PR created automatically by Jules for task [17916166186796163056](https://jules.google.com/task/17916166186796163056) started by @EffortlessSteven*