### PR TITLE
⚡ Bolt: [performance improvement] Optimize string allocations in secret redactor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+
+## 2026-03-26 - Regex Replacement Chain Optimization
+**Learning:** When chaining multiple regex replacements (e.g., `regex::Regex::replace_all`) in Rust, calling `.to_string()` repeatedly creates significant heap allocation overhead, even when no replacements are made.
+**Action:** Minimize heap allocations by maintaining the intermediate result as a `std::borrow::Cow<str>`. Re-assign it only when the replacement returns `Cow::Owned` (e.g., `if let Cow::Owned(s) = regex.replace_all(...)`), and call `.into_owned()` only at the end.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ toml = { workspace = true }
 globset = { workspace = true }
 fd-lock = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
-regex = { workspace = true }
+regex.workspace = true
 chrono = { workspace = true }
 once_cell = { workspace = true }
 sysinfo = { workspace = true }

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -561,15 +561,18 @@ impl SecretRedactor {
             return text.to_string();
         }
 
-        let mut redacted = text.to_string();
+        let mut redacted = std::borrow::Cow::Borrowed(text);
 
         for index in matches.iter() {
             if let Some((_, regex)) = self.patterns_linear.get(index) {
-                redacted = regex.replace_all(&redacted, "***").to_string();
+                let replaced = regex.replace_all(&redacted, "***");
+                if let std::borrow::Cow::Owned(s) = replaced {
+                    redacted = std::borrow::Cow::Owned(s);
+                }
             }
         }
 
-        redacted
+        redacted.into_owned()
     }
 
     /// Redact secrets from a vector of strings


### PR DESCRIPTION
💡 What: Modified `SecretRedactor::redact_string` to use `std::borrow::Cow` instead of immediately converting to `String` and allocating on every iteration.
🎯 Why: `regex.replace_all` natively returns a `Cow`. By chaining `.to_string()` in the previous loop, the application was forcefully allocating new heap memory for every single pattern checked against every line, even when no replacements occurred.
📊 Impact: Heavily reduces unnecessary heap allocations during the critical path of redacting secrets.
🔬 Measurement: Verify by running `cargo test -p xchecker-redaction`. Also visible in reduced memory churn when profiling `cargo test --workspace`.

---
*PR created automatically by Jules for task [15282330473469168042](https://jules.google.com/task/15282330473469168042) started by @EffortlessSteven*