### PR TITLE
🎨 Palette: Center TUI footer and add missing keyboard shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Explicit keyboard shortcuts discoverability]
+**Learning:** Explicitly documenting non-obvious keyboard shortcuts (like Home/End) directly in the UI footer significantly improves user discoverability and perceived accessibility, especially for users relying heavily on keyboard navigation. Center alignment for such footer elements establishes a clearer visual hierarchy in the TUI context.
+**Action:** When reviewing TUI components, always verify that all functional keyboard shortcuts are explicitly visible on the screen, rather than assuming users will try standard keybindings. Ensure help footers are center-aligned for better visual distinction from content areas.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,11 +680,12 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 What: Added explicit documentation for the Home/End keyboard shortcuts in the TUI footer, and center-aligned the text for a clearer visual hierarchy.
🎯 Why: Improves discoverability for keyboard users who might not know standard text navigation keybindings apply. Center alignment distinguishes the help footer from standard app content.
📸 Before/After: Before: Left-aligned missing "Home/End". After: Center-aligned including "Home/End: Top/Bottom".
♿ Accessibility: Explicitly surfacing available keyboard shortcuts makes the TUI more accessible to users relying heavily on keyboard navigation.

---
*PR created automatically by Jules for task [12129687261180888378](https://jules.google.com/task/12129687261180888378) started by @EffortlessSteven*