### PR TITLE
⚡ Bolt: [performance improvement] Cache extraction regexes with LazyLock

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+
+## 2024-07-26 - Regex Compilation Overhead in Extraction
+**Learning:** Recompiling regular expressions on every invocation of extraction functions causes significant and unnecessary CPU overhead.
+**Action:** Use `std::sync::LazyLock` to statically cache compiled regular expressions within function scopes to eliminate recompilation costs while keeping the refactoring localized.

--- a/crates/xchecker-extraction/src/lib.rs
+++ b/crates/xchecker-extraction/src/lib.rs
@@ -13,6 +13,7 @@
 //! Future B3.1 will add structured extraction of full requirement/design objects.
 
 use regex::Regex;
+use std::sync::LazyLock;
 
 /// Summary statistics extracted from a requirements markdown document
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -73,32 +74,32 @@ pub struct TasksSummary {
 /// ```
 #[must_use]
 pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
-    let mut summary = RequirementsSummary::default();
+    static USER_STORY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap());
+    static EARS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap()
+    });
+    static NFR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap());
+    static REQ_HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap());
 
-    // Match user story patterns: **User Story:** or **User Story**:
-    let user_story_re = Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap();
-    summary.user_story_count = user_story_re.find_iter(markdown).count();
-
-    // Match EARS-style acceptance criteria: WHEN ... THEN ... SHALL
-    // Also match simpler patterns: GIVEN/WHEN/THEN or numbered criteria with SHALL
-    let ears_re =
-        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap();
-    summary.acceptance_criteria_count = ears_re.find_iter(markdown).count();
-
-    // Match NFR patterns: **NFR-*, NFR-*, **Non-Functional*
-    let nfr_re = Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap();
-    summary.nfr_count = nfr_re.find_iter(markdown).count();
-
-    // Match requirement headings: ### Requirement N or ## Requirement N (allow leading whitespace)
-    let req_heading_re = Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap();
-    summary.requirement_count = req_heading_re.find_iter(markdown).count();
+    let user_story_count = USER_STORY_RE.find_iter(markdown).count();
+    let acceptance_criteria_count = EARS_RE.find_iter(markdown).count();
+    let nfr_count = NFR_RE.find_iter(markdown).count();
+    let mut requirement_count = REQ_HEADING_RE.find_iter(markdown).count();
 
     // If no formal requirement headings, try to count by user story count
-    if summary.requirement_count == 0 && summary.user_story_count > 0 {
-        summary.requirement_count = summary.user_story_count;
+    if requirement_count == 0 && user_story_count > 0 {
+        requirement_count = user_story_count;
     }
 
-    summary
+    RequirementsSummary {
+        requirement_count,
+        user_story_count,
+        acceptance_criteria_count,
+        nfr_count,
+    }
 }
 
 /// Extract summary metadata from a design markdown document
@@ -119,31 +120,22 @@ pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
 /// ```
 #[must_use]
 pub fn summarize_design(markdown: &str) -> DesignSummary {
-    let mut summary = DesignSummary::default();
+    static ARCH_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap());
+    static COMPONENT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap());
+    static INTERFACE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap());
+    static MODEL_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap());
 
-    // Check for architecture section (allow leading whitespace from indented doc content)
-    let arch_re = Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap();
-    summary.has_architecture = arch_re.is_match(markdown);
-
-    // Check for mermaid diagrams
-    summary.has_diagrams = markdown.contains("```mermaid");
-
-    // Count components: ### Component: X or ## Component: X or ### X Component
-    let component_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap();
-    summary.component_count = component_re.find_iter(markdown).count();
-
-    // Count interfaces: ### Interface: X or ## Interface: X or ### X API
-    let interface_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap();
-    summary.interface_count = interface_re.find_iter(markdown).count();
-
-    // Count data models: ## Data Model or ### Model: or ### Schema:
-    let model_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap();
-    summary.data_model_count = model_re.find_iter(markdown).count();
-
-    summary
+    DesignSummary {
+        has_architecture: ARCH_RE.is_match(markdown),
+        has_diagrams: markdown.contains("```mermaid"),
+        component_count: COMPONENT_RE.find_iter(markdown).count(),
+        interface_count: INTERFACE_RE.find_iter(markdown).count(),
+        data_model_count: MODEL_RE.find_iter(markdown).count(),
+    }
 }
 
 /// Extract summary metadata from a tasks markdown document
@@ -164,25 +156,21 @@ pub fn summarize_design(markdown: &str) -> DesignSummary {
 /// ```
 #[must_use]
 pub fn summarize_tasks(markdown: &str) -> TasksSummary {
-    let mut summary = TasksSummary::default();
+    static TASK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap());
+    static SUBTASK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap());
+    static MILESTONE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap());
+    static DEP_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap());
 
-    // Count tasks: ## Task N or ### Task N (allow leading whitespace from indented doc content)
-    let task_re = Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap();
-    summary.task_count = task_re.find_iter(markdown).count();
-
-    // Count subtasks: checkbox items - [ ] or - [x]
-    let subtask_re = Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap();
-    summary.subtask_count = subtask_re.find_iter(markdown).count();
-
-    // Count milestones: ## Milestone or ### Milestone
-    let milestone_re = Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap();
-    summary.milestone_count = milestone_re.find_iter(markdown).count();
-
-    // Count dependencies: "Depends on:" or "Dependencies:"
-    let dep_re = Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap();
-    summary.dependency_count = dep_re.find_iter(markdown).count();
-
-    summary
+    TasksSummary {
+        task_count: TASK_RE.find_iter(markdown).count(),
+        subtask_count: SUBTASK_RE.find_iter(markdown).count(),
+        milestone_count: MILESTONE_RE.find_iter(markdown).count(),
+        dependency_count: DEP_RE.find_iter(markdown).count(),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Statically cached all regular expressions in `xchecker-extraction` functions (`summarize_requirements`, `summarize_design`, `summarize_tasks`) using `std::sync::LazyLock`.

🎯 Why: Recompiling regular expressions on every invocation of extraction functions causes significant and unnecessary CPU overhead, especially since these functions are called frequently on markdown artifacts.

📊 Impact: Reduces CPU overhead on the markdown extraction hot path by compiling regexes exactly once per process.

🔬 Measurement: Run the xchecker extraction tests and observe reduced latency or CPU usage compared to recompiling regexes dynamically per function call.

*Note: Also removed sequential field mutations in favor of direct struct instantiations to resolve `clippy::field_reassign_with_default` warnings.*

---
*PR created automatically by Jules for task [4980048919959504787](https://jules.google.com/task/4980048919959504787) started by @EffortlessSteven*