### PR TITLE
🛡️ Sentinel: [security improvement] Add new secret redaction patterns

### DIFF
--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,14 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "openrouter_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"sk-or-v1-[a-f0-9]{64}",
+        description: "OpenRouter API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -262,8 +268,26 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "OpenSSH format markers",
     },
     // =========================================================================
-    // Platform-Specific Tokens (13 patterns)
+    // Platform-Specific Tokens (16 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "discord_token",
+        category: "Platform-Specific Tokens",
+        regex: r"[A-Za-z0-9_-]{15,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,}",
+        description: "Discord bot tokens",
+    },
+    SecretPatternDef {
+        id: "square_access_token",
+        category: "Platform-Specific Tokens",
+        regex: r"sq0atp-[A-Za-z0-9\-_]{22}",
+        description: "Square access tokens",
+    },
+    SecretPatternDef {
+        id: "slack_webhook",
+        category: "Platform-Specific Tokens",
+        regex: r"https://hooks\.slack\.com/services/T[A-Za-z0-9_]{8,10}/B[A-Za-z0-9_]{8,10}/[A-Za-z0-9_]{24}",
+        description: "Slack webhooks",
+    },
     SecretPatternDef {
         id: "hashicorp_vault_token",
         category: "Platform-Specific Tokens",
@@ -1495,5 +1519,9 @@ mod tests {
         assert!(pattern_ids.contains(&"pypi_token".to_string()));
         assert!(pattern_ids.contains(&"nuget_key".to_string()));
         assert!(pattern_ids.contains(&"docker_auth".to_string()));
+        assert!(pattern_ids.contains(&"openrouter_api_key".to_string()));
+        assert!(pattern_ids.contains(&"discord_token".to_string()));
+        assert!(pattern_ids.contains(&"square_access_token".to_string()));
+        assert!(pattern_ids.contains(&"slack_webhook".to_string()));
     }
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **49 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,7 +70,7 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
@@ -78,11 +78,13 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |
+| `openrouter_api_key` | `sk-or-v1-[a-f0-9]{64}` | OpenRouter API keys |
 
-#### Platform-Specific Tokens (13 patterns)
+#### Platform-Specific Tokens (16 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
+| `discord_token` | `[A-Za-z0-9_-]{15,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,}` | Discord bot tokens |
 | `docker_auth` | `"auth":\s*"[A-Za-z0-9+/=]{20,}"` | Docker registry auth tokens |
 | `github_app_token` | `gh[us]_[A-Za-z0-9]{36}` | GitHub App tokens |
 | `github_oauth` | `gho_[A-Za-z0-9]{36}` | GitHub OAuth tokens |
@@ -94,6 +96,8 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `pypi_token` | `pypi-[A-Za-z0-9_-]{50,}` | PyPI API tokens |
 | `sendgrid_key` | `SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}` | SendGrid API keys |
 | `slack_token` | `xox[baprs]-[A-Za-z0-9-]+` | Slack bot/user tokens |
+| `slack_webhook` | `https://hooks\.slack\.com/services/T[A-Za-z0-9_]{8,10}/B[A-Za-z0-9_]{8,10}/[A-Za-z0-9_]{24}` | Slack webhooks |
+| `square_access_token` | `sq0atp-[A-Za-z0-9\-_]{22}` | Square access tokens |
 | `stripe_key` | `sk_(?:live\|test)_[A-Za-z0-9]{24,}` | Stripe API keys |
 | `twilio_key` | `SK[A-Za-z0-9]{32}` | Twilio API keys |
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing secret redaction for OpenRouter, Discord, Square, and Slack Webhook tokens.
🎯 Impact: High risk of secret leakage in logs, outputs, and documentation.
🔧 Fix: Added new `SecretPatternDef` entries in `crates/xchecker-redaction/src/lib.rs` with their corresponding regexes to redact these secrets.
✅ Verification: Verified using `cargo test` and updated the assertions in `test_all_default_patterns_exist`.

---
*PR created automatically by Jules for task [6377219848148926148](https://jules.google.com/task/6377219848148926148) started by @EffortlessSteven*