### PR TITLE
🎨 Palette: Center-align TUI help footer and document Home/End shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-30 - Center-aligned TUI Help Footers
+**Learning:** TUI help footers should be center-aligned with DarkGray styling to establish a clear visual hierarchy, and all keyboard shortcuts must be explicitly documented to improve discoverability.
+**Action:** Always apply Alignment::Center and explicitly list all available shortcuts (like Home/End) when designing or updating TUI footers in xchecker.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,11 +680,12 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 What: Center-align the TUI help footer and document Home/End keyboard shortcuts.
🎯 Why: To establish a clear visual hierarchy and improve discoverability of existing keyboard navigation.
📸 Before/After: N/A (TUI changes)
♿ Accessibility: Improves keyboard discoverability for users relying on keyboard navigation.

---
*PR created automatically by Jules for task [15942878913331855706](https://jules.google.com/task/15942878913331855706) started by @EffortlessSteven*