### PR TITLE
🎨 Palette: Improve TUI help footer discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-01 - TUI Help Footer Alignment and Discoverability
+**Learning:** Left-aligned help footers in TUI applications are often overlooked by users scanning the interface, and missing shortcut documentation (like Home/End) leads to poor feature discoverability and reduced keyboard accessibility.
+**Action:** Always center-align TUI help footers using `.alignment(Alignment::Center)` to establish clear visual hierarchy, and ensure all active event loop shortcuts are explicitly documented in the help text.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,10 +680,11 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What:
Center-aligned the TUI help footer and explicitly added the `Home/End` keyboard shortcuts to the help text.

🎯 Why:
The help footer was left-aligned, making it harder to notice when scanning the interface. Furthermore, existing functional shortcuts (`Home` and `End`) were not documented, making them undiscoverable to users and reducing keyboard accessibility.

📸 Before/After:
Before:
`↑/k: Up  ↓/j: Down  Enter: Details  q: Quit` (left-aligned)

After:
`↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit` (center-aligned)

♿ Accessibility:
Improves keyboard accessibility by explicitly documenting all available navigation shortcuts and ensuring they are visually prominent via center-alignment.

---
*PR created automatically by Jules for task [8304323594607591708](https://jules.google.com/task/8304323594607591708) started by @EffortlessSteven*