### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in file reading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-02 - [HIGH] Fix TOCTOU vulnerability in file reading
+**Vulnerability:** File metadata was checked before opening the file, leaving a window for a race condition.
+**Learning:** Using `fs::read_to_string` after `fs::metadata` is unsafe as the file could be modified or swapped in between.
+**Prevention:** Always open the file first with `fs::File::open` and then use `file.metadata()` to check the size and other properties. Use `take()` to limit read size to prevent memory exhaustion.

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -438,6 +438,8 @@ impl PacketBuilder {
     }
 }
 
+use std::io::Read;
+
 /// Helper function to process a single candidate file in parallel.
 /// This encapsulates reading, hashing, redaction, and cache interaction.
 fn process_candidate_file(
@@ -447,8 +449,18 @@ fn process_candidate_file(
     redactor: &SecretRedactor,
     cache: Option<&Arc<Mutex<InsightCache>>>,
 ) -> Result<Option<(SelectedFile, String, usize, usize)>> {
-    // DoS protection: check file size before reading
-    let metadata = fs::metadata(&candidate.path)
+    // Optimization & Security: Open file first to avoid TOCTOU
+    let file = fs::File::open(&candidate.path);
+
+    // Check if it's a directory
+    if file.is_err() && fs::metadata(&candidate.path).is_ok_and(|meta| meta.is_dir()) {
+        return Ok(None);
+    }
+
+    let file = file.with_context(|| format!("Failed to open file: {}", candidate.path))?;
+
+    // DoS protection: check file size before reading to prevent memory exhaustion
+    let metadata = file.metadata()
         .with_context(|| format!("Failed to get file metadata: {}", candidate.path))?;
 
     if !metadata.is_file() {
@@ -476,9 +488,32 @@ fn process_candidate_file(
         return Ok(None);
     }
 
-    // Read content
-    let content = fs::read_to_string(&candidate.path)
+    // Read content safely, protecting against TOCTOU file growth
+    let mut content = String::with_capacity(metadata.len() as usize);
+    file.take(max_file_size + 1)
+        .read_to_string(&mut content)
         .with_context(|| format!("Failed to read file: {}", candidate.path))?;
+
+    // Post-read size check: handles case where file grew during read
+    if content.len() as u64 > max_file_size {
+        if candidate.priority == Priority::Upstream {
+            return Err(anyhow::anyhow!(
+                "Upstream file {} exceeds size limit of {} bytes (read: {}). \
+                 Critical context files must fit within the configured limit.",
+                candidate.path,
+                max_file_size,
+                content.len()
+            ));
+        }
+
+        tracing::warn!(
+            "Skipping large file: {} ({} bytes > limit {}) - file grew during read",
+            candidate.path,
+            content.len(),
+            max_file_size
+        );
+        return Ok(None);
+    }
 
     // Scan for secrets immediately after reading
     if redactor.has_secrets(&content, candidate.path.as_ref())? {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability existed when reading packet candidate files. The logic previously called `fs::metadata` followed sequentially by `fs::read_to_string`. This left a race condition where the file size could be checked against limits, but the file could be replaced or grow between the check and read, bypassing size constraints.
🎯 **Impact:** If exploited via concurrent modifications or symlink replacements, it could lead to excessive memory allocation (`fs::read_to_string` loads the entire file), potentially causing memory exhaustion and Denial of Service (DoS) during the packet building phase.
🔧 **Fix:** Refactored the reading logic to:
  1. Open the file first with `fs::File::open`.
  2. Check metadata size against the open file descriptor.
  3. Read the content with a bounded `take()` to enforce memory limits even if the file concurrently grows after the size check.
✅ **Verification:** 
  - Reviewed the code to ensure `std::io::Read::take` correctly restricts reading limits.
  - Ran workspace unit tests (`cargo test --workspace --lib`) to ensure behavior changes didn't break packet creation logic.
  - Ran linters to ensure code cleanliness.

---
*PR created automatically by Jules for task [2192687647191792459](https://jules.google.com/task/2192687647191792459) started by @EffortlessSteven*