### PR TITLE
🎨 Palette: [UX improvement] Center-align TUI help footer and add Home/End hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Center-align TUI help footer and add key hints
+**Learning:** Help footers in TUIs can easily go unnoticed if left-aligned or blended with the main content. Furthermore, implicit keyboard shortcuts (like Home/End) are invisible to users unless explicitly documented, reducing the discoverability of power-user features.
+**Action:** Always center-align TUI help footers (e.g., using `Alignment::Center`) to establish a clear visual hierarchy. Additionally, verify that all actively supported event loop keys are explicitly listed in the help text to improve discoverability.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,10 +680,11 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What: Center-aligned the TUI help footer and added explicitly documented `Home`, `End`, and `Esc` keyboard shortcuts to the main view help text.

🎯 Why: Center alignment establishes a clearer visual hierarchy for the footer. Explicitly documenting all supported shortcuts (like Home/End for Top/Bottom navigation) improves discoverability for users navigating the specs list, turning implicit power-user features into accessible tools.

📸 Before/After: Visual change in the terminal UI footer text and alignment. Help text now reads: `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit` and is centered.

♿ Accessibility: Better discoverability of keyboard shortcuts for power users and keyboard-only navigation.

---
*PR created automatically by Jules for task [10807025989091751786](https://jules.google.com/task/10807025989091751786) started by @EffortlessSteven*