### PR TITLE
🎨 Palette: Enhance TUI help footer discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-07 - Enhance TUI Help Footer Discoverability
+**Learning:** Keyboard-only interfaces require explicit, complete documentation in a clear visual hierarchy. Hidden or undocumented shortcuts (like `Home/End` for list boundaries) frustrate users. When adding help text to TUI components, center-aligning the footer using `Alignment::Center` makes it clearly distinct from left-aligned content above it.
+**Action:** Always ensure *all* implemented keyboard event shortcuts (e.g. `KeyCode::Home`) are visible in the contextual help footer. Use `Alignment::Center` and distinct styling (like `Color::DarkGray`) to separate help text visually from main content.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,11 +680,12 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 What: Enhanced the TUI help footer to explicitly document the `Home/End` keyboard shortcuts for navigating to the top and bottom of the list, and clarified `Esc/q` for quitting. Also center-aligned the footer text.
🎯 Why: Users of keyboard-only interfaces rely entirely on explicit documentation for discoverability. Hidden shortcuts frustrate users, and center-aligning the footer provides a clearer visual hierarchy, distinguishing the help text from the left-aligned main content.
📸 Before/After: Visual changes center the text and add the missing keys.
♿ Accessibility: Improves discoverability for keyboard navigation users.

---
*PR created automatically by Jules for task [1053111617712914326](https://jules.google.com/task/1053111617712914326) started by @EffortlessSteven*