### PR TITLE
🎨 Palette: Improve TUI help footer UX and discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-08 - TUI Help Footer Discoverability
+**Learning:** Hidden keyboard shortcuts in terminal interfaces lead to poor discoverability and accessibility. Without visual cues, users remain unaware of powerful navigation tools (like Home/End) or contextual exit behaviors (like context-dependent Esc).
+**Action:** Always document full keyboard navigation schemas in help footers, use center alignment to establish clear visual hierarchy, and ensure text accurately reflects the active view's context.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,10 +680,11 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home: First  End: Last  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What:
Center-aligned the help text within the TUI footer paragraph and updated the text to explicitly document `Home`, `End`, and the context-dependent `Esc/q` keys.

🎯 Why:
The application's main view supports `Home` and `End` for navigating to the first and last specs respectively, but this powerful feature was entirely undocumented, preventing user discovery. Furthermore, `Esc` was undocumented as an alternate main-view quit method (and 'back' in details view). Documenting these features and centering the help footer establishes a clearer visual hierarchy and ensures users can fully leverage the interface.

📸 Before/After:
**Before:** Left-aligned. Text read `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
**After:** Center-aligned. Text reads `↑/k: Up  ↓/j: Down  Home: First  End: Last  Enter: Details  Esc/q: Quit`

♿ Accessibility:
Exposing all active keyboard shortcuts significantly improves the interface's discoverability for users who rely heavily on keyboard navigation.

---
*PR created automatically by Jules for task [7841074079314558087](https://jules.google.com/task/7841074079314558087) started by @EffortlessSteven*