### PR TITLE
⚡ Bolt: [performance improvement] Cache error redaction regexes and minimize allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+
+## 2024-05-23 - Static Regex Compilation and Cow in Text Processing
+**Learning:** In functions called frequently on every log or path (like `redact_error_message_for_logging`), defining regexes inline causes them to be recompiled into state machines repeatedly, creating a massive CPU bottleneck. Additionally, unconditionally calling `to_string()` and reassigning `String`s when chaining regex replacements wastes heap allocations when strings aren't mutated.
+**Action:** Always statically cache compiled regular expressions using `std::sync::LazyLock` in hot loops/functions. Chain string mutations using `std::borrow::Cow` to eliminate allocations when no match/replacement is actually needed.

--- a/crates/xchecker-error-redaction/src/lib.rs
+++ b/crates/xchecker-error-redaction/src/lib.rs
@@ -77,26 +77,32 @@
 /// # Returns
 ///
 /// The redacted error message with sensitive information removed.
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
 pub fn redact_error_message_for_logging(message: &str) -> String {
-    let mut redacted = message.to_string();
+    let mut redacted = Cow::Borrowed(message);
 
     // Redact API keys (long alphanumeric strings with common prefixes)
     // Only redact strings that look like actual API keys (with prefixes like sk-, pk_, etc.)
     // Pattern: prefix followed by at least 20 alphanumeric characters
-    let api_key_regex =
-        regex::Regex::new(r"(?:sk-|pk_|api_key|secret|Bearer )[a-zA-Z0-9_-]{20,}").unwrap();
-    redacted = api_key_regex
-        .replace_all(&redacted, "[REDACTED_KEY]")
-        .to_string();
+    static API_KEY_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"(?:sk-|pk_|api_key|secret|Bearer )[a-zA-Z0-9_-]{20,}").unwrap()
+    });
+    if let Cow::Owned(s) = API_KEY_REGEX.replace_all(&redacted, "[REDACTED_KEY]") {
+        redacted = Cow::Owned(s);
+    }
 
     // Also redact long alphanumeric strings that look like keys (without explicit prefix)
     // Pattern: 32+ alphanumeric/underscore/dash characters that look like a key
     // Only match standalone keys (not embedded in URLs or after @)
     // Manually check boundaries to handle hyphens correctly (which \b doesn't handle well)
-    let long_key_regex = regex::Regex::new(r"[a-zA-Z0-9_-]{32,}").unwrap();
+    static LONG_KEY_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"[a-zA-Z0-9_-]{32,}").unwrap());
+
     let mut replacements = Vec::new();
 
-    for mat in long_key_regex.find_iter(&redacted) {
+    for mat in LONG_KEY_REGEX.find_iter(&redacted) {
         let start = mat.start();
         let end = mat.end();
 
@@ -121,30 +127,43 @@ pub fn redact_error_message_for_logging(message: &str) -> String {
         }
     }
 
-    // Apply replacements in reverse order to preserve indices
-    for (start, end) in replacements.into_iter().rev() {
-        redacted.replace_range(start..end, "[REDACTED_KEY]");
+    if !replacements.is_empty() {
+        let mut string_redacted = redacted.into_owned();
+        // Apply replacements in reverse order to preserve indices
+        for (start, end) in replacements.into_iter().rev() {
+            string_redacted.replace_range(start..end, "[REDACTED_KEY]");
+        }
+        redacted = Cow::Owned(string_redacted);
     }
 
     // Redact URLs with embedded credentials first to avoid breaking patterns
     // Pattern: `http://user:pass@host/path` or `https://token123:secret456@host/path`
-    let url_with_creds_regex = regex::Regex::new(r"https?://[a-zA-Z0-9_]+:[^:@\s]+@").unwrap();
-    redacted = url_with_creds_regex
-        .replace_all(&redacted, "[REDACTED]@")
-        .to_string();
+    static URL_WITH_CREDS_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"https?://[a-zA-Z0-9_]+:[^:@\s]+@").unwrap());
+    if let Cow::Owned(s) = URL_WITH_CREDS_REGEX.replace_all(&redacted, "[REDACTED]@") {
+        redacted = Cow::Owned(s);
+    }
 
     // Redact authentication credentials (passwords, tokens)
     if redacted.contains("password") || redacted.contains("token") {
         // Redact common password patterns - simpler regex without character class issues
-        let password_regex = regex::Regex::new(r"(?i)(password|pass|token)").unwrap();
-        redacted = password_regex.replace_all(&redacted, "***").to_string();
+        static PASSWORD_REGEX: LazyLock<regex::Regex> =
+            LazyLock::new(|| regex::Regex::new(r"(?i)(password|pass|token)").unwrap());
+        if let Cow::Owned(s) = PASSWORD_REGEX.replace_all(&redacted, "***") {
+            redacted = Cow::Owned(s);
+        }
     }
 
     // Redact file paths that may contain user-specific data
     // Normalize Windows paths
-    redacted = redacted.replace(r"C:\\", r"\");
-    redacted = redacted.replace(r"D:\\", r"\");
-    redacted
+    if redacted.contains(r"C:\\") || redacted.contains(r"D:\\") {
+        let mut string_redacted = redacted.into_owned();
+        string_redacted = string_redacted.replace(r"C:\\", r"\");
+        string_redacted = string_redacted.replace(r"D:\\", r"\");
+        redacted = Cow::Owned(string_redacted);
+    }
+
+    redacted.into_owned()
 }
 
 /// Redact sensitive information from error messages for display.
@@ -176,25 +195,38 @@ pub fn redact_error_message(message: &str) -> String {
 ///
 /// The redacted error message with paths normalized.
 pub fn redact_paths(message: &str) -> String {
-    let mut redacted = message.to_string();
+    let mut redacted = Cow::Borrowed(message);
 
     // Redact Unix-style home directories first (e.g., /home/user, /Users/user)
-    let unix_home_regex = regex::Regex::new(r"/(?:home|Users)/[^/\\\\]+").unwrap();
-    redacted = unix_home_regex.replace_all(&redacted, "[HOME]").to_string();
+    static UNIX_HOME_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"/(?:home|Users)/[^/\\\\]+").unwrap());
+    if let Cow::Owned(s) = UNIX_HOME_REGEX.replace_all(&redacted, "[HOME]") {
+        redacted = Cow::Owned(s);
+    }
 
     // Redact Windows home directories, optionally with a drive letter
-    let win_home_regex = regex::Regex::new(r"(?i)(?:[A-Za-z]:)?\\\\Users\\\\[^\\\\/]+").unwrap();
-    redacted = win_home_regex.replace_all(&redacted, "[HOME]").to_string();
+    static WIN_HOME_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"(?i)(?:[A-Za-z]:)?\\\\Users\\\\[^\\\\/]+").unwrap());
+    if let Cow::Owned(s) = WIN_HOME_REGEX.replace_all(&redacted, "[HOME]") {
+        redacted = Cow::Owned(s);
+    }
 
     // Redact Windows drive letters (C:\, D:\, etc.)
-    let drive_regex = regex::Regex::new(r"[A-Za-z]:\\\\").unwrap();
-    redacted = drive_regex.replace_all(&redacted, "[DRIVE]").to_string();
+    static DRIVE_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"[A-Za-z]:\\\\").unwrap());
+    if let Cow::Owned(s) = DRIVE_REGEX.replace_all(&redacted, "[DRIVE]") {
+        redacted = Cow::Owned(s);
+    }
 
     // Replace path separators to avoid leaking remaining path structure
-    redacted = redacted.replace("\\", "[PATH]");
-    redacted = redacted.replace("/", "[PATH]");
+    if redacted.contains('\\') || redacted.contains('/') {
+        let mut string_redacted = redacted.into_owned();
+        string_redacted = string_redacted.replace('\\', "[PATH]");
+        string_redacted = string_redacted.replace('/', "[PATH]");
+        redacted = Cow::Owned(string_redacted);
+    }
 
-    redacted
+    redacted.into_owned()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Statically cache regexes using `LazyLock` and chain string replacements using `Cow` in `xchecker-error-redaction`.
🎯 Why: Prevent DoS/CPU exhaustion from compiling complex regexes on every error log call, and minimize heap allocations when redacting error messages.
📊 Impact: Significantly reduces CPU overhead and memory allocations for error message handling.
🔬 Measurement: Observe reduction in CPU time spent in regex compilation and fewer heap allocations per error log.

---
*PR created automatically by Jules for task [9974554320371248987](https://jules.google.com/task/9974554320371248987) started by @EffortlessSteven*