### PR TITLE
🎨 Palette: Improve TUI help footer UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - TUI Help Footer Completeness and Alignment
+**Learning:** Terminal User Interfaces (TUIs) often have context-dependent keyboard shortcuts that are easily missed by users. Center-aligning the help footer and explicitly listing *all* available navigation keys (like Home/End) improves discoverability and establishes a clearer visual hierarchy.
+**Action:** When updating or designing TUI components, ensure all implemented keyboard event listeners are documented in the help text and use center alignment for footer components to separate them clearly from the main content.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,10 +680,11 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home: First  End: Last  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What:
Updated the TUI help footer to explicitly list all available context-dependent keyboard shortcuts (Home, End, Esc, q) and center-aligned the text.

🎯 Why:
TUIs rely entirely on keyboard navigation. When shortcuts like `Home`/`End` (to jump to the top/bottom of a list) or the dual use of `Esc/q` are hidden, users are forced to guess or read source code. Center-aligning the footer clearly separates it from the left-aligned main content, establishing a better visual hierarchy.

📸 Before/After:
**Before:**
`↑/k: Up  ↓/j: Down  Enter: Details  q: Quit` (left-aligned)

**After:**
`↑/k: Up  ↓/j: Down  Home: First  End: Last  Enter: Details  Esc/q: Quit` (center-aligned)

♿ Accessibility:
Improves keyboard shortcut discoverability and establishes clearer visual hierarchy for users relying on the terminal interface.

---
*PR created automatically by Jules for task [12015076870616220727](https://jules.google.com/task/12015076870616220727) started by @EffortlessSteven*