### PR TITLE
🎨 Palette: TUI Help Footer explicit shortcuts and center alignment

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-11 - TUI Help Footer UX Polish
+**Learning:** Terminal User Interfaces (TUI) often rely heavily on keyboard shortcuts. Users can easily miss shortcuts if they aren't explicitly documented. The visual hierarchy of a help footer is improved by center alignment.
+**Action:** Ensure all available keybindings (e.g., Home/End) are explicitly documented in help footers. Center align help footers to establish a clear visual hierarchy.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,10 +680,11 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What: Explicitly documented missing keyboard shortcuts (`Home`/`End` and `Esc`) in the main view's TUI help footer and center-aligned the text to improve visual hierarchy.
🎯 Why: Keyboard shortcuts in TUIs are often missed if not explicitly documented. Center-aligning the footer creates a better visual boundary for the help section.
📸 Before/After: Before: Left-aligned, "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit". After: Center-aligned, "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit".
♿ Accessibility: Improves discoverability for keyboard navigation shortcuts.

---
*PR created automatically by Jules for task [9345513021135276789](https://jules.google.com/task/9345513021135276789) started by @EffortlessSteven*