### PR TITLE
🎨 Palette: Improve TUI help footer discoverability and layout

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [TUI Keyboard Discoverability]
+**Learning:** Documenting full context-aware shortcuts (like Home/End) directly in the persistent UI footer is critical for command-line interfaces lacking mouse discoverability.
+**Action:** Always verify application source bindings (e.g. event loops in rust ratatui) against user-facing documentation to identify hidden but fully functional hotkeys and elevate them into view using center alignment for visual priority.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,11 +680,12 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);
 }


### PR DESCRIPTION
💡 What: Centered the text in the TUI help footer and documented the missing `Home`/`End` shortcuts.
🎯 Why: Keyboard users had no way of discovering that they could jump to the top and bottom of the specs list without reading the source code. Centering the footer text establishes a stronger visual hierarchy, separating the global help from the main content.
📸 Before/After: Before, text was left-aligned and lacked `Home`/`End` keys. Now, text is center-aligned and reads: `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit`.
♿ Accessibility: Improves keyboard discoverability significantly for non-mouse command line interfaces by clearly stating all available contextual navigation bindings directly in the persistent UI.

---
*PR created automatically by Jules for task [4384118479376321204](https://jules.google.com/task/4384118479376321204) started by @EffortlessSteven*