### PR TITLE
🎨 Palette: Update TUI help footer to reflect context-dependent Esc behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-28 - TUI Help Footer Alignment and Context-Aware 'Esc' Text
+**Learning:** In Ratatui TUI interfaces, `Paragraph` block titles inherit the block's text alignment unless explicitly overridden. When center-aligning help text, the "Help" title can inadvertently move to the center. Additionally, context-dependent keybinds (like 'Esc' exiting the app vs. going back) must be accurately reflected in help footers to avoid user confusion.
+**Action:** When center-aligning a widget's text, apply `Line::from(" Title ").alignment(Alignment::Left)` to its surrounding block title to keep the title left-aligned. Ensure help footers accurately describe the context-dependent actions of keyboard bindings (e.g., "Esc/q: Quit" vs "Esc: Back").

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-runner/src/command_spec.rs
+++ b/crates/xchecker-runner/src/command_spec.rs
@@ -24,7 +24,7 @@ use tokio::process::Command as TokioCommand;
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::CommandSpec;
+/// use xchecker_runner::CommandSpec;
 /// use std::ffi::OsString;
 ///
 /// let cmd = CommandSpec::new("claude")
@@ -58,7 +58,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude");
     /// ```
@@ -84,7 +84,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .arg("--print")
@@ -108,7 +108,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .args(["--print", "--output-format", "json"]);
@@ -132,7 +132,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .cwd("/path/to/workspace");
@@ -153,7 +153,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .env("CLAUDE_API_KEY", "sk-...")
@@ -176,7 +176,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .envs([("DEBUG", "1"), ("VERBOSE", "true")]);
@@ -203,7 +203,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("echo")
     ///     .arg("hello")
@@ -236,7 +236,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// # async fn example() {
     /// let cmd = CommandSpec::new("echo")

--- a/crates/xchecker-runner/src/native.rs
+++ b/crates/xchecker-runner/src/native.rs
@@ -31,7 +31,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{NativeRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{NativeRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = NativeRunner::new();
@@ -51,7 +51,7 @@ impl NativeRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::NativeRunner;
+    /// use xchecker_runner::NativeRunner;
     ///
     /// let runner = NativeRunner::new();
     /// ```

--- a/crates/xchecker-runner/src/process.rs
+++ b/crates/xchecker-runner/src/process.rs
@@ -75,8 +75,8 @@ impl ProcessOutput {
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::{ProcessRunner, CommandSpec, ProcessOutput};
-/// use xchecker_utils::error::RunnerError;
+/// use xchecker_runner::{ProcessRunner, CommandSpec, ProcessOutput};
+/// use xchecker_runner::RunnerError;
 /// use std::time::Duration;
 ///
 /// struct SimpleRunner;

--- a/crates/xchecker-runner/src/wsl.rs
+++ b/crates/xchecker-runner/src/wsl.rs
@@ -32,7 +32,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{WslRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{WslRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = WslRunner::new();
@@ -55,7 +55,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::new();
     /// ```
@@ -73,7 +73,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::with_distro("Ubuntu-22.04");
     /// ```

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,17 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Line::from(" Help ").alignment(Alignment::Left)),
+        );
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What:
Updated the TUI interface help footer to accurately reflect the functionality of the `Esc` key contextually, adding `Esc` to the main view quit keys (`Esc/q: Quit`). Also fixed the layout by correctly centering the help text and cleanly left-aligning the "Help" block title.

🎯 Why:
The help footer previously stated `q: Quit` on the main view, but hitting `Esc` actually exits the application there. Users pressing `Esc` out of habit (often used for dismissing focus or returning) could unexpectedly quit without understanding why. This makes the interface more transparent. Additionally, aligning the block title fixes visual layout issues where Ratatui paragraphs awkwardly inherit alignment.

📸 Before/After:
Before:
- Text: "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
- Alignment: Everything implicitly centered or improperly constrained.

After:
- Text: "↑/k: Up  ↓/j: Down  Enter: Details  Esc/q: Quit"
- Alignment: Text centered, " Help " block title left-aligned.

♿ Accessibility:
Ensures keyboard interactions are accurately conveyed to the user, particularly for terminal power-users who rely heavily on standard keybind muscle memory (`Esc` to cancel/back/quit).

*Note: Also fixed some residual doctest compilation errors in workspace crates using external paths internally.*

---
*PR created automatically by Jules for task [11587160910894115140](https://jules.google.com/task/11587160910894115140) started by @EffortlessSteven*