### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix TOCTOU vulnerability in file context building

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-29 - TOCTOU Vulnerability in File Reading
+**Vulnerability:** Time-of-check to time-of-use (TOCTOU) race condition when reading files for packet building. The code checked the file metadata size and then read the entire file via path. If the file grew concurrently between the metadata check and the read operation, it could lead to memory exhaustion (DoS).
+**Learning:** `fs::read_to_string` does not enforce read limits based on prior metadata checks, exposing a TOCTOU gap in environments where files are modified dynamically.
+**Prevention:** Always open a `fs::File` descriptor first, run `file.metadata()` on the opened descriptor to ensure consistent referencing, and use the `Read::take` adapter on the file descriptor to enforce a hard byte limit during the read operation itself.

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use blake3::Hasher;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::fs;
+use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use xchecker_config::Selectors;
@@ -447,8 +448,13 @@ fn process_candidate_file(
     redactor: &SecretRedactor,
     cache: Option<&Arc<Mutex<InsightCache>>>,
 ) -> Result<Option<(SelectedFile, String, usize, usize)>> {
-    // DoS protection: check file size before reading
-    let metadata = fs::metadata(&candidate.path)
+    // Optimization: Open file once to avoid redundant path resolution and TOCTOU
+    let file = fs::File::open(&candidate.path)
+        .with_context(|| format!("Failed to open file: {}", candidate.path))?;
+
+    // DoS protection: check file size before reading to prevent memory exhaustion
+    // Note: file.metadata() follows symlinks if opened via fs::File::open
+    let metadata = file.metadata()
         .with_context(|| format!("Failed to get file metadata: {}", candidate.path))?;
 
     if !metadata.is_file() {
@@ -477,8 +483,35 @@ fn process_candidate_file(
     }
 
     // Read content
-    let content = fs::read_to_string(&candidate.path)
+    // Pre-allocate buffer to avoid reallocations
+    let mut content = String::with_capacity(metadata.len() as usize);
+
+    // Security: Use take() to enforce hard limit on read size
+    // This prevents DoS if the file grows concurrently (TOCTOU race)
+    file.take(max_file_size + 1)
+        .read_to_string(&mut content)
         .with_context(|| format!("Failed to read file: {}", candidate.path))?;
+
+    // Post-read size check: handles case where file grew during read
+    if content.len() as u64 > max_file_size {
+        if candidate.priority == Priority::Upstream {
+            return Err(anyhow::anyhow!(
+                "Upstream file {} exceeds size limit of {} bytes (read: {}). \
+                 Critical context files must fit within the configured limit.",
+                candidate.path,
+                max_file_size,
+                content.len()
+            ));
+        }
+
+        tracing::warn!(
+            "Skipping large file: {} ({} bytes > limit {}) - file grew during read",
+            candidate.path,
+            content.len(),
+            max_file_size
+        );
+        return Ok(None);
+    }
 
     // Scan for secrets immediately after reading
     if redactor.has_secrets(&content, candidate.path.as_ref())? {

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-runner/src/command_spec.rs
+++ b/crates/xchecker-runner/src/command_spec.rs
@@ -24,7 +24,7 @@ use tokio::process::Command as TokioCommand;
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::CommandSpec;
+/// use xchecker_runner::CommandSpec;
 /// use std::ffi::OsString;
 ///
 /// let cmd = CommandSpec::new("claude")
@@ -58,7 +58,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude");
     /// ```
@@ -84,7 +84,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .arg("--print")
@@ -108,7 +108,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .args(["--print", "--output-format", "json"]);
@@ -132,7 +132,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .cwd("/path/to/workspace");
@@ -153,7 +153,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .env("CLAUDE_API_KEY", "sk-...")
@@ -176,7 +176,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .envs([("DEBUG", "1"), ("VERBOSE", "true")]);
@@ -203,7 +203,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("echo")
     ///     .arg("hello")
@@ -236,7 +236,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// # async fn example() {
     /// let cmd = CommandSpec::new("echo")

--- a/crates/xchecker-runner/src/native.rs
+++ b/crates/xchecker-runner/src/native.rs
@@ -31,7 +31,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{NativeRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{NativeRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = NativeRunner::new();
@@ -51,7 +51,7 @@ impl NativeRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::NativeRunner;
+    /// use xchecker_runner::NativeRunner;
     ///
     /// let runner = NativeRunner::new();
     /// ```

--- a/crates/xchecker-runner/src/process.rs
+++ b/crates/xchecker-runner/src/process.rs
@@ -75,8 +75,8 @@ impl ProcessOutput {
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::{ProcessRunner, CommandSpec, ProcessOutput};
-/// use xchecker_utils::error::RunnerError;
+/// use xchecker_runner::{ProcessRunner, CommandSpec, ProcessOutput};
+/// use xchecker_runner::RunnerError;
 /// use std::time::Duration;
 ///
 /// struct SimpleRunner;

--- a/crates/xchecker-runner/src/wsl.rs
+++ b/crates/xchecker-runner/src/wsl.rs
@@ -32,7 +32,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{WslRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{WslRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = WslRunner::new();
@@ -55,7 +55,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::new();
     /// ```
@@ -73,7 +73,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::with_distro("Ubuntu-22.04");
     /// ```


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-of-check to time-of-use (TOCTOU) race condition when reading files for packet building. `process_candidate_file` previously checked `fs::metadata` by path and then read the entire file using `fs::read_to_string`. If a file grew between the metadata check and the read, memory could be exhausted (DoS).
🎯 Impact: Attackers or concurrent processes could bypass size limits on upstream/context files, causing OOM conditions in the CLI and pipeline disruptions.
🔧 Fix: Opened the file using `fs::File::open` to establish a safe descriptor. Fetched metadata directly from the descriptor to avoid race conditions. Bounded the actual read operation using `.take(max_file_size + 1)` to prevent infinite/excessive reads. Handled post-read limit enforcement properly. Also included some small doctest import fixes in runner/receipt.
✅ Verification: `cargo test --workspace` passes, pre-commit clippy passes. Tested reading large/growing files using `take()`.

---
*PR created automatically by Jules for task [16136303058381233268](https://jules.google.com/task/16136303058381233268) started by @EffortlessSteven*