### PR TITLE
🎨 Palette: Center help footer and clarify Esc behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-30 - Center Alignment Inheritance in Ratatui
+**Learning:** In Ratatui, when center-aligning the content of a Paragraph widget (like a help footer), the block's title will incorrectly inherit this center alignment by default, causing awkward visual layout.
+**Action:** Always explicitly apply `Line::from(" Title ").alignment(Alignment::Left)` to the block title to preserve correct title positioning when centering paragraph content.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What:
Centered the help footer text in the TUI application and explicitly left-aligned its title. Also, updated the help text to clarify that `Esc` exits the main view.

🎯 Why:
The help footer text was previously left-aligned, which made it look less polished compared to the rest of the UI. Center alignment provides a better visual balance. Additionally, the footer previously didn't mention that `Esc` exits the app when on the main view, which caused confusion. Now it clearly says `Esc/q: Quit`.

📸 Before/After:
Before: Left-aligned help text, `q: Quit`.
After: Centered help text, `Esc/q: Quit`. The title `Help` remains correctly left-aligned.

♿ Accessibility:
No changes to screen-reader or keyboard navigation accessibility, but improves cognitive clarity by making keyboard shortcuts more explicit.

---
*PR created automatically by Jules for task [5902886386649860206](https://jules.google.com/task/5902886386649860206) started by @EffortlessSteven*