### PR TITLE
🎨 Palette: Center help footer and add missing shortcuts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-01 - Center Aligning Ratatui Titles
+**Learning:** Ratatui's `Paragraph` block titles inherit the main widget's alignment. If the `Paragraph` text is center-aligned but the block title should be left-aligned (e.g., in a help footer), `Line::from(" Title ").alignment(Alignment::Left)` must be explicitly applied to the block title.
+**Action:** Use `alignment(Alignment::Left)` on block titles explicitly when changing a block's alignment to `Center` to avoid visual regressions in the UI framing.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,17 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Line::from(" Help ").alignment(Alignment::Left)),
+        );
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Added center alignment to help footer, left-aligned its title, and added missing `Home/End` and `Esc` shortcuts to main view help text.
🎯 Why: Improves usability by accurately showing all context-dependent shortcuts, and provides a balanced visual polish by centering the footer text.
📸 Before/After: N/A (TUI changes)
♿ Accessibility: Enhances discoverability of existing keyboard shortcuts (`Home/End` and `Esc` for quit in main view).

---
*PR created automatically by Jules for task [6689796115382974548](https://jules.google.com/task/6689796115382974548) started by @EffortlessSteven*