### PR TITLE
🎨 Palette: Add Home/End keyboard hints and clarify Esc behavior in TUI footer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-02 - Accurate Context-Dependent Help Text
+**Learning:** Keyboard navigation hints must accurately reflect all implemented keybindings (like Home/End) and context-dependent behaviors (like Esc quitting vs going back) to prevent user confusion. Additionally, when center-aligning help text, the block title must be explicitly left-aligned using `Line::from(...).alignment(Alignment::Left)` to prevent it from inheriting the content's center alignment.
+**Action:** Always verify help footers against the active event loop logic and ensure block titles maintain correct alignment when content alignment changes.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,17 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Line::from(" Help ").alignment(Alignment::Left)),
+        );
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 **What:** 
Updated the TUI's help footer text to include existing `Home`/`End` keybindings, and clarified the behavior of the `Esc` key (which quits the app in the main view, but acts as "back" in the details view). The help text has also been center-aligned for better visual polish, while keeping the "Help" block title left-aligned to match Ratatui layout conventions.

🎯 **Why:** 
The event loop supported `KeyCode::Home` and `KeyCode::End` shortcuts, but they were hidden from users. Furthermore, users might have been confused about `Esc` acting as a "quit" operation on the main screen, as it wasn't listed in the hints.

📸 **Before/After:**
*Before:* `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit` (Left-aligned)
*After:* `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit` (Center-aligned)

♿ **Accessibility:**
Makes keyboard navigation options explicit to screen readers and keyboard-only users by fully documenting all available interaction paths directly in the visible UI.

---
*PR created automatically by Jules for task [2292437496855325053](https://jules.google.com/task/2292437496855325053) started by @EffortlessSteven*