### PR TITLE
🎨 Palette: Improve TUI help footer hints and alignment

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-03 - TUI Help Footer Context and Alignment
+**Learning:** Ratatui `Paragraph` widgets configured with center alignment incorrectly inherit that alignment to their block titles. Furthermore, keyboard shortcuts in TUIs often have hidden functionality (like Home/End) or context-dependent behaviors (like Esc) that are not communicated to the user, leading to confusing UX.
+**Action:** Use `Line::from(" Title ").alignment(Alignment::Left)` for block titles to override paragraph center alignment, and ensure all active navigation shortcuts are accurately documented in context-aware help footers.

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Improved the TUI help footer by center-aligning the hint text while keeping the "Help" block title left-aligned. Also surfaced undocumented keyboard shortcuts (`Home`/`End` for Top/Bottom, `Esc/q` for Quit) in the main view.

🎯 Why: To provide a more polished visual appearance and ensure users are fully aware of all available keyboard navigation options, reducing friction when interacting with the list.

📸 Before/After:
Before: Left-aligned help text missing `Home`/`End` shortcuts and not indicating `Esc` behavior in the main view.
After: Center-aligned help text explicitly listing `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit`.

♿ Accessibility: Improves keyboard discoverability by explicitly documenting all active navigation shortcuts.

---
*PR created automatically by Jules for task [8937407742782835689](https://jules.google.com/task/8937407742782835689) started by @EffortlessSteven*