### PR TITLE
🛡️ Sentinel: [MEDIUM] Cache regex to prevent CPU exhaustion in error redaction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - Prevent CPU Exhaustion (DoS) in Error Redaction via Regex Compilation Caching
+**Vulnerability:** Dynamically compiling regular expressions on every call in the high-traffic `xchecker-error-redaction` crate created a CPU exhaustion bottleneck (DoS vulnerability / CWE-400).
+**Learning:** Even utility functions intended for security (like error redaction) can become attack vectors if expensive operations like regex compilation occur on every invocation.
+**Prevention:** Always statically cache compiled regular expressions using `std::sync::LazyLock` in frequently executed paths to eliminate redundant compilation overhead.

--- a/crates/xchecker-error-redaction/src/lib.rs
+++ b/crates/xchecker-error-redaction/src/lib.rs
@@ -83,9 +83,10 @@ pub fn redact_error_message_for_logging(message: &str) -> String {
     // Redact API keys (long alphanumeric strings with common prefixes)
     // Only redact strings that look like actual API keys (with prefixes like sk-, pk_, etc.)
     // Pattern: prefix followed by at least 20 alphanumeric characters
-    let api_key_regex =
-        regex::Regex::new(r"(?:sk-|pk_|api_key|secret|Bearer )[a-zA-Z0-9_-]{20,}").unwrap();
-    redacted = api_key_regex
+    static API_KEY_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"(?:sk-|pk_|api_key|secret|Bearer )[a-zA-Z0-9_-]{20,}").unwrap()
+    });
+    redacted = API_KEY_REGEX
         .replace_all(&redacted, "[REDACTED_KEY]")
         .to_string();
 
@@ -93,10 +94,12 @@ pub fn redact_error_message_for_logging(message: &str) -> String {
     // Pattern: 32+ alphanumeric/underscore/dash characters that look like a key
     // Only match standalone keys (not embedded in URLs or after @)
     // Manually check boundaries to handle hyphens correctly (which \b doesn't handle well)
-    let long_key_regex = regex::Regex::new(r"[a-zA-Z0-9_-]{32,}").unwrap();
+    static LONG_KEY_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"[a-zA-Z0-9_-]{32,}").unwrap()
+    });
     let mut replacements = Vec::new();
 
-    for mat in long_key_regex.find_iter(&redacted) {
+    for mat in LONG_KEY_REGEX.find_iter(&redacted) {
         let start = mat.start();
         let end = mat.end();
 
@@ -128,16 +131,20 @@ pub fn redact_error_message_for_logging(message: &str) -> String {
 
     // Redact URLs with embedded credentials first to avoid breaking patterns
     // Pattern: `http://user:pass@host/path` or `https://token123:secret456@host/path`
-    let url_with_creds_regex = regex::Regex::new(r"https?://[a-zA-Z0-9_]+:[^:@\s]+@").unwrap();
-    redacted = url_with_creds_regex
+    static URL_WITH_CREDS_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"https?://[a-zA-Z0-9_]+:[^:@\s]+@").unwrap()
+    });
+    redacted = URL_WITH_CREDS_REGEX
         .replace_all(&redacted, "[REDACTED]@")
         .to_string();
 
     // Redact authentication credentials (passwords, tokens)
     if redacted.contains("password") || redacted.contains("token") {
         // Redact common password patterns - simpler regex without character class issues
-        let password_regex = regex::Regex::new(r"(?i)(password|pass|token)").unwrap();
-        redacted = password_regex.replace_all(&redacted, "***").to_string();
+        static PASSWORD_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+            regex::Regex::new(r"(?i)(password|pass|token)").unwrap()
+        });
+        redacted = PASSWORD_REGEX.replace_all(&redacted, "***").to_string();
     }
 
     // Redact file paths that may contain user-specific data
@@ -179,16 +186,22 @@ pub fn redact_paths(message: &str) -> String {
     let mut redacted = message.to_string();
 
     // Redact Unix-style home directories first (e.g., /home/user, /Users/user)
-    let unix_home_regex = regex::Regex::new(r"/(?:home|Users)/[^/\\\\]+").unwrap();
-    redacted = unix_home_regex.replace_all(&redacted, "[HOME]").to_string();
+    static UNIX_HOME_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"/(?:home|Users)/[^/\\\\]+").unwrap()
+    });
+    redacted = UNIX_HOME_REGEX.replace_all(&redacted, "[HOME]").to_string();
 
     // Redact Windows home directories, optionally with a drive letter
-    let win_home_regex = regex::Regex::new(r"(?i)(?:[A-Za-z]:)?\\\\Users\\\\[^\\\\/]+").unwrap();
-    redacted = win_home_regex.replace_all(&redacted, "[HOME]").to_string();
+    static WIN_HOME_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"(?i)(?:[A-Za-z]:)?\\\\Users\\\\[^\\\\/]+").unwrap()
+    });
+    redacted = WIN_HOME_REGEX.replace_all(&redacted, "[HOME]").to_string();
 
     // Redact Windows drive letters (C:\, D:\, etc.)
-    let drive_regex = regex::Regex::new(r"[A-Za-z]:\\\\").unwrap();
-    redacted = drive_regex.replace_all(&redacted, "[DRIVE]").to_string();
+    static DRIVE_REGEX: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"[A-Za-z]:\\\\").unwrap()
+    });
+    redacted = DRIVE_REGEX.replace_all(&redacted, "[DRIVE]").to_string();
 
     // Replace path separators to avoid leaking remaining path structure
     redacted = redacted.replace("\\", "[PATH]");


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Dynamically compiling regular expressions on every call in the high-traffic `xchecker-error-redaction` crate created a CPU exhaustion bottleneck (DoS vulnerability / CWE-400).
🎯 Impact: An attacker could potentially exhaust server resources by triggering error paths that repeatedly compile complex regular expressions.
🔧 Fix: Statically cached all compiled regular expressions in `crates/xchecker-error-redaction/src/lib.rs` using `std::sync::LazyLock` in frequently executed paths to eliminate redundant compilation overhead.
✅ Verification: Ran `cargo test -p xchecker-error-redaction` and `cargo test --workspace` to ensure redaction logic remains intact and fast.

---
*PR created automatically by Jules for task [3203495359183477415](https://jules.google.com/task/3203495359183477415) started by @EffortlessSteven*