### PR TITLE
🎨 Palette: Add missing keyboard shortcut hints to TUI help footer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-04 - TUI Keyboard Shortcut Hints
+**Learning:** Hidden keyboard shortcuts (like Home/End) exist in the event loop but aren't discoverable. Keeping help footers in sync with implemented event loops is critical for keyboard accessibility and discoverability.
+**Action:** When adding or discovering keyboard navigation shortcuts in a TUI, ensure the help footers accurately advertise them to the user.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home: Top  End: Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added missing `Home: Top`, `End: Bottom`, and `Esc` to the TUI's main help footer.
🎯 Why: The TUI event loop supports Home and End navigation and uses Esc to quit, but these features were completely hidden from the user, degrading discoverability.
📸 Before/After: Before: "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit". After: "↑/k: Up  ↓/j: Down  Home: Top  End: Bottom  Enter: Details  Esc/q: Quit".
♿ Accessibility: Improves keyboard accessibility by making navigation options explicit and discoverable, especially for users relying primarily on keyboard interaction.

---
*PR created automatically by Jules for task [7352607768920209547](https://jules.google.com/task/7352607768920209547) started by @EffortlessSteven*