### PR TITLE
🎨 Palette: Improve keyboard shortcut discoverability in TUI footer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - Ensure TUI Help Footers Advertise All Event-Loop Shortcuts
+**Learning:** In Ratatui applications, missing shortcut advertisements (like Home/End or context-dependent Esc behavior) lead to poor keyboard accessibility. Furthermore, center-aligning Paragraph widgets inadvertently center-aligns their Block titles unless explicitly styled with `Line::from("Title").alignment(Alignment::Left)`.
+**Action:** Always verify all keyboard shortcuts bound in the event loop are explicitly listed in the help footer. Use `Line::from(" Title ").alignment(Alignment::Left)` for block titles when center-aligning Paragraph content.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Update the TUI help footer to include missing Home/End shortcuts and context-dependent Esc behavior, and center-align the footer text for better visual hierarchy.
🎯 Why: To ensure all supported keyboard shortcuts are discoverable and to prevent the help block title from incorrectly inheriting center alignment when the help text is center-aligned.
📸 Before/After: Before: "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit" (Left-aligned text). After: "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit" (Center-aligned text, left-aligned title).
♿ Accessibility: Improves keyboard discoverability, making it easier for users relying on keyboards/screen-readers to know the full range of supported navigation commands.

---
*PR created automatically by Jules for task [15251573766051347200](https://jules.google.com/task/15251573766051347200) started by @EffortlessSteven*