### PR TITLE
🛡️ Sentinel: Add Gemini API key redaction

### DIFF
--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -184,6 +184,12 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "OpenAI Legacy API keys",
     },
     SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
+    SecretPatternDef {
         id: "huggingface_token",
         category: "LLM Provider Tokens",
         regex: r"hf_[A-Za-z0-9]{34}",


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing secret detection pattern for Gemini API keys (`AIzaSy...`).
🎯 Impact: Without this pattern, Gemini API keys could be unintentionally exposed or leaked in xchecker packets when generating specifications.
🔧 Fix: Added the `gemini_api_key` pattern to `DEFAULT_SECRET_PATTERNS` in `xchecker-redaction/src/lib.rs` under the "LLM Provider Tokens" category.
✅ Verification: Ran `cargo test` on the workspace and specifically for `xchecker-redaction`. Also confirmed `cargo clippy --workspace` passes cleanly.

---
*PR created automatically by Jules for task [11598677042756973966](https://jules.google.com/task/11598677042756973966) started by @EffortlessSteven*