### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in file selection

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,9 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2026-02-12 - TOCTOU Vulnerability in Packet Assembly
+
+**Vulnerability:** `process_candidate_file` checked file sizes via `fs::metadata(path)` and later read the file using `fs::read_to_string(path)`. This gap allows for a Time-Of-Check to Time-Of-Use (TOCTOU) race condition where a file could be swapped or grow after the size check but before reading, potentially causing memory exhaustion or reading unintended data.
+**Learning:** Checking file metadata by path and then reading by path is vulnerable to race conditions.
+**Prevention:** Open the file via `File::open` first, then call `.metadata()` on the open file descriptor to ensure the metadata matches the file you will actually read. Use `file.take(limit).read_to_string()` to strictly bound the memory usage even if the file grows during the read.

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use blake3::Hasher;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::fs;
+use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use xchecker_config::Selectors;
@@ -447,8 +448,12 @@ fn process_candidate_file(
     redactor: &SecretRedactor,
     cache: Option<&Arc<Mutex<InsightCache>>>,
 ) -> Result<Option<(SelectedFile, String, usize, usize)>> {
+    // Optimization: Open file once to avoid redundant path resolution and TOCTOU
+    let file = fs::File::open(&candidate.path)
+        .with_context(|| format!("Failed to open file: {}", candidate.path))?;
+
     // DoS protection: check file size before reading
-    let metadata = fs::metadata(&candidate.path)
+    let metadata = file.metadata()
         .with_context(|| format!("Failed to get file metadata: {}", candidate.path))?;
 
     if !metadata.is_file() {
@@ -476,9 +481,35 @@ fn process_candidate_file(
         return Ok(None);
     }
 
-    // Read content
-    let content = fs::read_to_string(&candidate.path)
+    // Pre-allocate buffer to avoid reallocations
+    let mut content = String::with_capacity(metadata.len() as usize);
+
+    // Security: Use take() to enforce hard limit on read size
+    // This prevents DoS if the file grows concurrently (TOCTOU race)
+    file.take(max_file_size + 1)
+        .read_to_string(&mut content)
         .with_context(|| format!("Failed to read file: {}", candidate.path))?;
+
+    // Post-read size check: handles case where file grew during read
+    if content.len() as u64 > max_file_size {
+        if candidate.priority == Priority::Upstream {
+            return Err(anyhow::anyhow!(
+                "Upstream file {} exceeds size limit of {} bytes (read: {}). \
+                 Critical context files must fit within the configured limit.",
+                candidate.path,
+                max_file_size,
+                content.len()
+            ));
+        }
+
+        tracing::warn!(
+            "Skipping large file: {} ({} bytes > limit {}) - file grew during read",
+            candidate.path,
+            content.len(),
+            max_file_size
+        );
+        return Ok(None);
+    }
 
     // Scan for secrets immediately after reading
     if redactor.has_secrets(&content, candidate.path.as_ref())? {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: process_candidate_file had a Time-Of-Check to Time-Of-Use vulnerability checking fs::metadata(path) then using fs::read_to_string.
🎯 Impact: Allows an attacker to bypass file size limits or read sensitive files via race conditions.
🔧 Fix: Use fs::File::open to acquire a file descriptor first, then check its metadata. Enforce file size limit during reading via file.take().
✅ Verification: Verified via full workspace tests.

---
*PR created automatically by Jules for task [5755010361753855776](https://jules.google.com/task/5755010361753855776) started by @EffortlessSteven*