### PR TITLE
🛡️ Sentinel: [HIGH] Add missing Gemini API key redaction

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,9 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2025-02-15 - Missing Gemini API Keys in Secret Detection
+
+**Vulnerability:** The default secret detection patterns were missing Gemini API keys (`AIzaSy...`). Because `xchecker` interacts with LLMs including Gemini, missing this pattern leaves users vulnerable to leaking their API keys.
+**Learning:** When adding support for new LLM providers, always ensure their specific API key formats are added to `DEFAULT_SECRET_PATTERNS`.
+**Prevention:** Add provider-specific keys (like `gemini_api_key` with format `AIzaSy[A-Za-z0-9_-]{33}`) to the redaction library immediately when integrating new services.

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,14 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -1461,6 +1467,7 @@ mod tests {
         assert!(pattern_ids.contains(&"jwt_token".to_string()));
 
         // LLM Provider Tokens
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
         assert!(pattern_ids.contains(&"anthropic_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The default secret detection patterns in `xchecker-redaction` lacked a pattern for Gemini API keys (`AIzaSy...`). Since `xchecker` interacts with LLMs including Gemini, missing this pattern leaves users vulnerable to leaking their API keys in logs or transmitted context packets.
🎯 Impact: An attacker could obtain leaked Gemini API keys, allowing them to impersonate the user, access Google Cloud resources, or incur unexpected billing costs on the user's behalf.
🔧 Fix: Added a new `SecretPatternDef` for `gemini_api_key` with the regex `AIzaSy[A-Za-z0-9_-]{33}` to `DEFAULT_SECRET_PATTERNS`. Also added corresponding test assertions and updated the generated `SECURITY.md` documentation.
✅ Verification: Ran `cargo test --workspace` and `cargo run --bin regenerate_secret_patterns_docs --features="dev-tools"` to ensure tests pass and documentation is updated.

---
*PR created automatically by Jules for task [3838643193583537457](https://jules.google.com/task/3838643193583537457) started by @EffortlessSteven*