### PR TITLE
🎨 Palette: Explicit keyboard shortcuts and title alignment fix in TUI

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-05-12 - [TUI Help Footers and Titles Alignment]
+**Learning:** In Ratatui, when center-aligning a Paragraph widget (like an empty state or footer), the block's title inherits that center alignment, causing broken UI. Missing shortcuts in TUI footers also reduce discoverability.
+**Action:** Explicitly set `Line::from(" Title ").alignment(Alignment::Left)` for block titles to override the paragraph's alignment, and ensure all active keyboard events are explicitly advertised in the Help text.

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::writer::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::writer::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -463,7 +463,7 @@ fn render_specs_list(f: &mut Frame, app: &TuiApp, area: Rect) {
         ];
 
         let empty = Paragraph::new(empty_text)
-            .block(Block::default().borders(Borders::ALL).title(" Specs "))
+            .block(Block::default().borders(Borders::ALL).title(Line::from(" Specs ").alignment(Alignment::Left)))
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: true });
         f.render_widget(empty, area);
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)))
+        .alignment(Alignment::Center);
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Added Home/End shortcuts to TUI footer, center-aligned footer text, and fixed inherited title centering in empty states and footers.
🎯 Why: Center-aligned titles in blocks look broken; missing shortcuts reduce keyboard discoverability.
📸 Before/After: Visual fix for TUI.
♿ Accessibility: Improved keyboard navigation discoverability.

---
*PR created automatically by Jules for task [14820999536346508160](https://jules.google.com/task/14820999536346508160) started by @EffortlessSteven*