### PR TITLE
🎨 Palette: Add Home/End keyboard shortcut hints to TUI footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,6 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+## 2026-01-24 - [Keyboard Navigation Discoverability]
+**Learning:** Hidden keyboard shortcuts limit accessibility and discoverability. The TUI event loop implemented Home and End keys for navigation but did not advertise them.
+**Action:** Always ensure that any keyboard shortcuts implemented in the event loop are explicitly advertised in the UI's help footers.

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::writer::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::writer::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Added Home/End key hints to the TUI help text footer and center-aligned the text.
🎯 Why: The TUI event loop supported Home/End for scrolling to the top/bottom of the spec list, but these shortcuts were hidden from the user, reducing discoverability and accessibility. Center aligning the footer also balances the visual layout.
📸 Before/After: N/A (TUI visual change)
♿ Accessibility: Explicitly advertising supported keyboard shortcuts directly in the UI allows users who rely on keyboard navigation to fully utilize the application without needing to guess or consult external documentation.

---
*PR created automatically by Jules for task [10915740344165027466](https://jules.google.com/task/10915740344165027466) started by @EffortlessSteven*