### PR TITLE
🎨 Palette: Add keyboard shortcuts hints for better accessibility

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-06-08 - [TUI Keyboard Shortcut Discoverability]
+**Learning:** Hidden keyboard shortcuts (like Home, End, and Esc) reduce accessibility and frustrate users who rely on keyboard navigation. In TUI widgets like Paragraphs, center alignment can mistakenly inherit to block titles if not explicitly overridden.
+**Action:** Always document all active keyboard bindings in the help footer to maintain discoverability. Use `Line::from(" Title ").alignment(Alignment::Left)` on TUI block titles to explicitly prevent inheritance of center alignment.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,12 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Updated the TUI help footer to explicitly list the `Home`, `End`, and context-dependent `Esc` keyboard shortcuts. Also explicitly forced `Alignment::Left` on the help block title so that it isn't incorrectly inherited from the center alignment.
🎯 Why: Hidden keyboard shortcuts frustrate users who rely on keyboard navigation and reduce overall interface accessibility. Ensuring all bindings are documented makes the application significantly more discoverable.
📸 Before/After: Visual update on the help text footer.
♿ Accessibility: Increased visibility of keyboard navigation options, which directly benefits users who prefer or require keyboard-only interaction.

---
*PR created automatically by Jules for task [5001076059568809715](https://jules.google.com/task/5001076059568809715) started by @EffortlessSteven*