### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing Gemini API Key redaction

### DIFF
--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -189,6 +189,12 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         regex: r"hf_[A-Za-z0-9]{34}",
         description: "Hugging Face access tokens",
     },
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     // =========================================================================
     // Database Connection URLs (5 patterns)
     // =========================================================================
@@ -1135,6 +1141,22 @@ mod tests {
     }
 
     #[test]
+    fn test_gemini_token_detection() {
+        let redactor = SecretRedactor::new().unwrap();
+        let token = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
+        let content = format!("export GEMINI_API_KEY={}", token);
+
+        let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern_id, "gemini_api_key");
+
+        let result = redactor.redact_content(&content, "test.txt").unwrap();
+        assert!(result.has_secrets);
+        assert!(result.content.contains("[REDACTED:gemini_api_key]"));
+        assert!(!result.content.contains(token));
+    }
+
+    #[test]
     fn test_line_number_accuracy() {
         let redactor = SecretRedactor::new().unwrap();
         let token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
@@ -1465,6 +1487,7 @@ mod tests {
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));
         assert!(pattern_ids.contains(&"huggingface_token".to_string()));
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
 
         // Database URLs
         assert!(pattern_ids.contains(&"postgres_url".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The redaction tool did not include a pattern to detect and redact Gemini API keys (`AIzaSy...`), which are sensitive LLM provider tokens.
🎯 Impact: Accidental leakage of Gemini API keys via logging, generated context packets, or user-facing strings.
🔧 Fix: Added a regex pattern for Gemini API keys under the "LLM Provider Tokens" category in `crates/xchecker-redaction/src/lib.rs` and regenerated documentation.
✅ Verification: Ran unit tests validating Gemini API key detection and `cargo run --bin regenerate_secret_patterns_docs` verified documentation sync.

---
*PR created automatically by Jules for task [4204475831435420288](https://jules.google.com/task/4204475831435420288) started by @EffortlessSteven*