### PR TITLE
🎨 Palette: Add keyboard shortcuts to TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [Discoverable TUI Keybindings]
+**Learning:** Keyboard shortcuts implemented in event loops remain undiscoverable unless explicitly advertised, degrading accessibility. Also, block titles inherit the block's text alignment unless explicitly overridden.
+**Action:** Always explicitly list supported keybindings (like Home/End) in the UI's help footer, and use `Line::from(" Title ").alignment(Alignment::Left)` on block titles when center-aligning block content.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Added explicitly advertised Home/End keybindings to the TUI help footer, and center-aligned the text.
🎯 Why: Keybindings implemented in event loops remain undiscoverable unless explicitly advertised in the UI. Center-aligning the footer makes it more visually distinct.
📸 Before/After: Visual changes to footer block.
♿ Accessibility: Improves keyboard navigation discoverability.

---
*PR created automatically by Jules for task [10104595822043883964](https://jules.google.com/task/10104595822043883964) started by @EffortlessSteven*