### PR TITLE
🛡️ Sentinel: [HIGH] Add Gemini and OpenRouter API key detection

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,11 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2026-06-12 - Missing LLM Provider Tokens for Gemini and OpenRouter
+
+**Vulnerability:** The default secret detection patterns missed Gemini and OpenRouter API keys. Given that `xchecker` is an LLM-orchestration tool and OpenRouter / Gemini are valid configuration options, accidental inclusion of these keys is a high-probability risk.
+
+**Learning:** When building tools that integrate with specific 3rd-party services (like LLMs), always prioritize secret detection for those specific services' credentials. Generic patterns like GCP API keys do not correctly cover the specific length constraint of Gemini keys (`AIzaSy`), and OpenRouter keys (`sk-or-v1-...`) are entirely missing.
+
+**Prevention:** Regularly audit secret detection patterns against the specific integrations used by the tool and its users. Check the config validation code to see which providers are supported.

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,20 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (6 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
+    SecretPatternDef {
+        id: "openrouter_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"sk-or-v1-[a-zA-Z0-9]{64}",
+        description: "OpenRouter API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -1461,6 +1473,8 @@ mod tests {
         assert!(pattern_ids.contains(&"jwt_token".to_string()));
 
         // LLM Provider Tokens
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
+        assert!(pattern_ids.contains(&"openrouter_api_key".to_string()));
         assert!(pattern_ids.contains(&"anthropic_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **47 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,14 +70,16 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (6 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |
+| `openrouter_api_key` | `sk-or-v1-[a-zA-Z0-9]{64}` | OpenRouter API keys |
 
 #### Platform-Specific Tokens (13 patterns)
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The default secret detection patterns missed Gemini and OpenRouter API keys. Given that `xchecker` is an LLM-orchestration tool and OpenRouter / Gemini are valid configuration options, accidental inclusion of these keys is a high-probability risk.
🎯 Impact: Accidental leakage of valid LLM provider credentials to logs, artifacts, or untrusted external APIs via unredacted configuration files.
🔧 Fix: Added new regex patterns `AIzaSy[A-Za-z0-9_-]{33}` for Gemini and `sk-or-v1-[a-zA-Z0-9]{64}` for OpenRouter to `DEFAULT_SECRET_PATTERNS`.
✅ Verification: Tested against existing logic via unit tests in `crates/xchecker-redaction/src/lib.rs`. Regenerated `docs/SECURITY.md` successfully.

---
*PR created automatically by Jules for task [891157779685286800](https://jules.google.com/task/891157779685286800) started by @EffortlessSteven*