### PR TITLE
🎨 Palette: Explicitly advertise Home/End/Esc in TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,6 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+## 2025-02-18 - TUI Help Footer Discoverability and Alignment
+**Learning:** TUI help footers must advertise all available keyboard shortcuts (like Home/End and Esc) implemented in the event loop to ensure proper keyboard accessibility and discoverability. Additionally, when center-aligning Ratatui Paragraph text, the block title must explicitly be left-aligned (`Line::from(" Title ").alignment(Alignment::Left)`) to prevent it from inheriting the content's center alignment.
+**Action:** Always cross-reference the TUI event loop for implemented shortcuts against the help footer, and explicitly enforce alignment on block titles when applying alignment to parent widgets.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,17 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
+        .alignment(Alignment::Center)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Line::from(" Help ").alignment(Alignment::Left)),
+        );
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Updated the TUI help footer to explicitly advertise the `Home/End` and `Esc` keyboard shortcuts that are implemented in the event loop, and center-aligned the paragraph text while preserving the left alignment of the block title.
🎯 Why: To improve the discoverability and accessibility of the TUI's keyboard navigation. Center-aligning the paragraph text also provides a nice visual polish typical of TUI help footers.
📸 Before/After: Before, only `Up/Down` and `Enter` were advertised. Now, `Home/End` and `Esc` are also advertised.
♿ Accessibility: Improves keyboard accessibility by ensuring all available shortcuts are discoverable.

---
*PR created automatically by Jules for task [7788405158997224863](https://jules.google.com/task/7788405158997224863) started by @EffortlessSteven*