### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing Gemini API key detection in redaction

### DIFF
--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,14 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -1465,6 +1471,7 @@ mod tests {
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));
         assert!(pattern_ids.contains(&"huggingface_token".to_string()));
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
 
         // Database URLs
         assert!(pattern_ids.contains(&"postgres_url".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The redaction engine failed to detect and redact Gemini API keys, allowing them to be potentially exposed or transmitted in logs and tool context packets.
🎯 Impact: Accidental exposure of Gemini API keys could allow unauthorized access to the user's Gemini service and AI workloads.
🔧 Fix: Added the explicit regex pattern for Gemini API keys (`AIzaSy[A-Za-z0-9_-]{33}`) to `DEFAULT_SECRET_PATTERNS` under the "LLM Provider Tokens" category and regenerated the documentation.
✅ Verification: Ran `cargo test` to ensure the new pattern is registered and passes the validation checks in `xchecker-redaction`.

---
*PR created automatically by Jules for task [1131362633806331908](https://jules.google.com/task/1131362633806331908) started by @EffortlessSteven*