### PR TITLE
🎨 Palette: Improve TUI keyboard shortcut discoverability

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [TUI Keyboard Discoverability]
+**Learning:** Hidden keyboard shortcuts (Home/End) and context-dependent behavior (Esc to quit vs back) exclude keyboard-reliant users. Also, Ratatui Paragraph titles inherit center alignment from content, breaking visual hierarchy.
+**Action:** Always explicitly document all supported shortcuts in UI footers. Center text using `Alignment::Center` on the Paragraph, but reset title alignment with `Line::from(" Title ").alignment(Alignment::Left)`.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,12 +680,13 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home: First  End: Last  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)
         .style(Style::default().fg(Color::DarkGray))
-        .block(Block::default().borders(Borders::ALL).title(" Help "));
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL).title(Line::from(" Help ").alignment(Alignment::Left)));
     f.render_widget(footer, area);
 }
 


### PR DESCRIPTION
💡 What: Added missing `Home`, `End`, and `Esc` shortcut hints to the TUI footer and center-aligned the help text while preserving left-aligned titles.
🎯 Why: To make navigation features visible to users and improve the visual hierarchy of the footer block.
📸 Before/After: Before, only up/down/enter/quit were shown and text was left-aligned. After, all event loop actions are visible and text is centered nicely.
♿ Accessibility: Keyboard navigation is now fully discoverable, enabling users who rely on keyboards to use quick navigation features they otherwise wouldn't know existed.

---
*PR created automatically by Jules for task [13429882456478207171](https://jules.google.com/task/13429882456478207171) started by @EffortlessSteven*