### PR TITLE
🎨 Palette: Add Home/End keyboard shortcut hints to TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [Keyboard Shortcut Discoverability]
+**Learning:** Users cannot utilize keyboard shortcuts (like Home/End) if they are not explicitly advertised in the UI. Hidden shortcuts lead to accessibility gaps.
+**Action:** Ensure all keyboard navigation options are clearly documented in the help footers of TUI applications.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added explicit "Home/End: Top/Bottom" keyboard shortcut hints to the TUI help footer.

🎯 Why: To improve discoverability of existing, faster navigation options for keyboard-centric users.

📸 Before/After: N/A

♿ Accessibility: Ensures that keyboard shortcuts implemented in the TUI event loop are clearly advertised, making the interface more intuitive and accessible for power users or those relying entirely on keyboard navigation.

---
*PR created automatically by Jules for task [14227348733902683721](https://jules.google.com/task/14227348733902683721) started by @EffortlessSteven*