### PR TITLE
🎨 Palette: Add Home/End shortcuts to TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-05-24 - [Missing help texts for key bindings]
+**Learning:** Adding new keybinds but forgetting to mention them in the UI help footers makes them completely undiscoverable to new users.
+**Action:** Always verify that every implemented key binding (especially movement like Home/End) is accurately reflected in the corresponding UI help text section.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added `Home/End: Top/Bottom` to the UI help text in the TUI application footer.
🎯 Why: The TUI event loop already supported `Home` and `End` keys to jump to the top or bottom of the workspace list, but this functionality was completely undiscoverable to users because it was omitted from the on-screen help footer.
📸 Before/After: N/A (Text change)
♿ Accessibility: Improves usability by ensuring all keyboard navigation options are explicitly advertised to users, reducing reliance on trial and error or external documentation.

---
*PR created automatically by Jules for task [6758340876128488883](https://jules.google.com/task/6758340876128488883) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only help footer and internal UX notes; no behavior or security changes.
> 
> **Overview**
> The workspace TUI footer help text now lists **`Home/End: Top/Bottom`** next to the existing ↑/k and ↓/j hints, so jump-to-first/last on the spec list matches what the event loop already does.
> 
> A Jules UX palette note was added to treat **every key binding as part of the on-screen help**, especially movement shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deba7e717696df7c1e5855a4e615d1d406dfa4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->