### PR TITLE
🛡️ Sentinel: [HIGH] Fix Secret Redaction Missing Gemini API Keys

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,9 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2026-01-25 - Missing Gemini API Keys in Secret Detection
+
+**Vulnerability:** The default secret detection patterns missed Gemini API keys.
+**Learning:** When building tools that integrate with specific 3rd-party services (like LLMs), always prioritize secret detection for those specific services' credentials. Gemini API keys follow a specific `AIzaSy` format that was omitted.
+**Prevention:** Regularly audit secret detection patterns against the specific integrations used by the tool and its users to ensure new LLM provider keys are included.

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,14 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -1461,6 +1467,7 @@ mod tests {
         assert!(pattern_ids.contains(&"jwt_token".to_string()));
 
         // LLM Provider Tokens
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
         assert!(pattern_ids.contains(&"anthropic_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The default secret detection patterns missed Gemini API keys.
🎯 Impact: Gemini API keys could be accidentally leaked in outputs or logs because the `SecretRedactor` would not catch and sanitize them.
🔧 Fix: Added the `gemini_api_key` pattern (`AIzaSy[A-Za-z0-9_-]{33}`) to `DEFAULT_SECRET_PATTERNS` in the `xchecker-redaction` crate under the 'LLM Provider Tokens' category. Also updated tests and regenerated documentation.
✅ Verification: Ran `cargo test --workspace` and regenerated `docs/SECURITY.md`. Verified that `test_all_default_patterns_exist` now explicitly checks for `gemini_api_key`.

---
*PR created automatically by Jules for task [12606616611244840738](https://jules.google.com/task/12606616611244840738) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive secret-detection pattern only; no changes to auth, packet flow, or redaction logic beyond one new regex.
> 
> **Overview**
> Adds **`gemini_api_key`** (`AIzaSy[A-Za-z0-9_-]{33}`) to `DEFAULT_SECRET_PATTERNS` in **LLM Provider Tokens**, so `SecretRedactor` can block or redact Gemini credentials in packets and logs alongside other LLM provider keys.
> 
> **`test_all_default_patterns_exist`** now asserts `gemini_api_key`. **`docs/SECURITY.md`** is regenerated (46 patterns; LLM category 5). **`.jules/security/sentinel.md`** records the gap and prevention note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b45d412b32780bdb510460d333872d22136d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->