### PR TITLE
⚡ Bolt: Cache Regex compilation in extraction module

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+## 2024-06-17 - Cache Regex compilation with LazyLock
+**Learning:** The `xchecker-extraction` module repeatedly compiles regular expressions inside functions like `summarize_requirements`, `summarize_design`, and `summarize_tasks` on every invocation. Compiling regexes is computationally expensive.
+**Action:** When performing regex matching, always use `std::sync::LazyLock` to cache compiled regexes as static variables to eliminate repeated regex compilation overhead.

--- a/crates/xchecker-extraction/src/lib.rs
+++ b/crates/xchecker-extraction/src/lib.rs
@@ -13,6 +13,38 @@
 //! Future B3.1 will add structured extraction of full requirement/design objects.
 
 use regex::Regex;
+use std::sync::LazyLock;
+
+static USER_STORY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap());
+static EARS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap()
+});
+static NFR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap()
+});
+static REQ_HEADING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap());
+static ARCH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap()
+});
+static COMPONENT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap()
+});
+static INTERFACE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap()
+});
+static MODEL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap()
+});
+static TASK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap());
+static SUBTASK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap());
+static MILESTONE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap());
+static DEP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap());
 
 /// Summary statistics extracted from a requirements markdown document
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -73,25 +105,12 @@ pub struct TasksSummary {
 /// ```
 #[must_use]
 pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
-    let mut summary = RequirementsSummary::default();
-
-    // Match user story patterns: **User Story:** or **User Story**:
-    let user_story_re = Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap();
-    summary.user_story_count = user_story_re.find_iter(markdown).count();
-
-    // Match EARS-style acceptance criteria: WHEN ... THEN ... SHALL
-    // Also match simpler patterns: GIVEN/WHEN/THEN or numbered criteria with SHALL
-    let ears_re =
-        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap();
-    summary.acceptance_criteria_count = ears_re.find_iter(markdown).count();
-
-    // Match NFR patterns: **NFR-*, NFR-*, **Non-Functional*
-    let nfr_re = Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap();
-    summary.nfr_count = nfr_re.find_iter(markdown).count();
-
-    // Match requirement headings: ### Requirement N or ## Requirement N (allow leading whitespace)
-    let req_heading_re = Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap();
-    summary.requirement_count = req_heading_re.find_iter(markdown).count();
+    let mut summary = RequirementsSummary {
+        user_story_count: USER_STORY_RE.find_iter(markdown).count(),
+        acceptance_criteria_count: EARS_RE.find_iter(markdown).count(),
+        nfr_count: NFR_RE.find_iter(markdown).count(),
+        requirement_count: REQ_HEADING_RE.find_iter(markdown).count(),
+    };
 
     // If no formal requirement headings, try to count by user story count
     if summary.requirement_count == 0 && summary.user_story_count > 0 {
@@ -119,31 +138,13 @@ pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
 /// ```
 #[must_use]
 pub fn summarize_design(markdown: &str) -> DesignSummary {
-    let mut summary = DesignSummary::default();
-
-    // Check for architecture section (allow leading whitespace from indented doc content)
-    let arch_re = Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap();
-    summary.has_architecture = arch_re.is_match(markdown);
-
-    // Check for mermaid diagrams
-    summary.has_diagrams = markdown.contains("```mermaid");
-
-    // Count components: ### Component: X or ## Component: X or ### X Component
-    let component_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap();
-    summary.component_count = component_re.find_iter(markdown).count();
-
-    // Count interfaces: ### Interface: X or ## Interface: X or ### X API
-    let interface_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap();
-    summary.interface_count = interface_re.find_iter(markdown).count();
-
-    // Count data models: ## Data Model or ### Model: or ### Schema:
-    let model_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap();
-    summary.data_model_count = model_re.find_iter(markdown).count();
-
-    summary
+    DesignSummary {
+        has_architecture: ARCH_RE.is_match(markdown),
+        has_diagrams: markdown.contains("```mermaid"),
+        component_count: COMPONENT_RE.find_iter(markdown).count(),
+        interface_count: INTERFACE_RE.find_iter(markdown).count(),
+        data_model_count: MODEL_RE.find_iter(markdown).count(),
+    }
 }
 
 /// Extract summary metadata from a tasks markdown document
@@ -164,25 +165,12 @@ pub fn summarize_design(markdown: &str) -> DesignSummary {
 /// ```
 #[must_use]
 pub fn summarize_tasks(markdown: &str) -> TasksSummary {
-    let mut summary = TasksSummary::default();
-
-    // Count tasks: ## Task N or ### Task N (allow leading whitespace from indented doc content)
-    let task_re = Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap();
-    summary.task_count = task_re.find_iter(markdown).count();
-
-    // Count subtasks: checkbox items - [ ] or - [x]
-    let subtask_re = Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap();
-    summary.subtask_count = subtask_re.find_iter(markdown).count();
-
-    // Count milestones: ## Milestone or ### Milestone
-    let milestone_re = Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap();
-    summary.milestone_count = milestone_re.find_iter(markdown).count();
-
-    // Count dependencies: "Depends on:" or "Dependencies:"
-    let dep_re = Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap();
-    summary.dependency_count = dep_re.find_iter(markdown).count();
-
-    summary
+    TasksSummary {
+        task_count: TASK_RE.find_iter(markdown).count(),
+        subtask_count: SUBTASK_RE.find_iter(markdown).count(),
+        milestone_count: MILESTONE_RE.find_iter(markdown).count(),
+        dependency_count: DEP_RE.find_iter(markdown).count(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-runner/src/command_spec.rs
+++ b/crates/xchecker-runner/src/command_spec.rs
@@ -24,7 +24,7 @@ use tokio::process::Command as TokioCommand;
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::CommandSpec;
+/// use xchecker_runner::CommandSpec;
 /// use std::ffi::OsString;
 ///
 /// let cmd = CommandSpec::new("claude")
@@ -58,7 +58,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude");
     /// ```
@@ -84,7 +84,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .arg("--print")
@@ -108,7 +108,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .args(["--print", "--output-format", "json"]);
@@ -132,7 +132,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .cwd("/path/to/workspace");
@@ -153,7 +153,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .env("CLAUDE_API_KEY", "sk-...")
@@ -176,7 +176,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .envs([("DEBUG", "1"), ("VERBOSE", "true")]);
@@ -203,7 +203,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("echo")
     ///     .arg("hello")
@@ -236,7 +236,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// # async fn example() {
     /// let cmd = CommandSpec::new("echo")

--- a/crates/xchecker-runner/src/native.rs
+++ b/crates/xchecker-runner/src/native.rs
@@ -31,7 +31,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{NativeRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{NativeRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = NativeRunner::new();
@@ -51,7 +51,7 @@ impl NativeRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::NativeRunner;
+    /// use xchecker_runner::NativeRunner;
     ///
     /// let runner = NativeRunner::new();
     /// ```

--- a/crates/xchecker-runner/src/process.rs
+++ b/crates/xchecker-runner/src/process.rs
@@ -75,8 +75,8 @@ impl ProcessOutput {
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::{ProcessRunner, CommandSpec, ProcessOutput};
-/// use xchecker_utils::error::RunnerError;
+/// use xchecker_runner::{ProcessRunner, CommandSpec, ProcessOutput};
+/// use xchecker_runner::error::RunnerError;
 /// use std::time::Duration;
 ///
 /// struct SimpleRunner;

--- a/crates/xchecker-runner/src/wsl.rs
+++ b/crates/xchecker-runner/src/wsl.rs
@@ -32,7 +32,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{WslRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{WslRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = WslRunner::new();
@@ -55,7 +55,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::new();
     /// ```
@@ -73,7 +73,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::with_distro("Ubuntu-22.04");
     /// ```


### PR DESCRIPTION
💡 What: Cache regular expressions using `std::sync::LazyLock` in `crates/xchecker-extraction/src/lib.rs`.
🎯 Why: To avoid repeatedly compiling regular expressions inside `summarize_requirements`, `summarize_design`, and `summarize_tasks`, which is computationally expensive.
📊 Impact: Removes the overhead of repeatedly compiling regex patterns on every extraction pass, significantly speeding up the application.
🔬 Measurement: The regex compilation is now done exactly once per process. Tests pass and behavior remains functionally identical.

---
*PR created automatically by Jules for task [3444684493774040472](https://jules.google.com/task/3444684493774040472) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance refactor in metadata extraction plus documentation-only import fixes; no logic or API changes beyond compile-once regex usage.
> 
> **Overview**
> **`xchecker-extraction`** no longer builds the same `regex::Regex` values on every call to `summarize_requirements`, `summarize_design`, and `summarize_tasks`. Those patterns are moved to process-wide `static` `LazyLock<Regex>` handles and the summarize functions only run matching/counting against them, with the same fallback when requirement headings are missing.
> 
> Doc examples are corrected to reference **`xchecker_runner`** and **`xchecker_receipt`** instead of outdated `xchecker_utils` / `xchecker_engine` paths. **`.jules/bolt.md`** records the LazyLock pattern for future Bolt tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cadf7eb9a868503ae07e5f317f2c11dc491981cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->