### PR TITLE
🛡️ Sentinel: CRITICAL Fix missing Gemini API key redaction pattern

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,8 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+## 2024-06-17 - Missing Gemini API Key in Secret Detection
+
+**Vulnerability:** The default secret detection patterns in `crates/xchecker-redaction/src/lib.rs` missed Gemini API keys. This could lead to accidental inclusion and exposure of Gemini API keys when building tool contexts or generating receipts.
+**Learning:** Always ensure all used integration tokens and API keys are included in the default secret patterns list, especially newly added or frequently used LLM providers.
+**Prevention:** Regularly audit the `DEFAULT_SECRET_PATTERNS` to ensure coverage for all integrated services and LLM providers.

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,13 +163,19 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
         regex: r"sk-ant-api03-[A-Za-z0-9_-]{20,}",
         description: "Anthropic API keys",
+    },
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
     },
     SecretPatternDef {
         id: "openai_api_key",
@@ -1465,6 +1471,7 @@ mod tests {
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));
         assert!(pattern_ids.contains(&"huggingface_token".to_string()));
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
 
         // Database URLs
         assert!(pattern_ids.contains(&"postgres_url".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Missing Gemini API key in `DEFAULT_SECRET_PATTERNS` allowed accidental inclusion and exposure of these keys in tool contexts or receipts.
🎯 Impact: An attacker could extract exposed Gemini API keys and use them for unauthorized access to the LLM provider.
🔧 Fix: Added the `gemini_api_key` pattern (using the regex `AIzaSy[A-Za-z0-9_-]{33}`) to the "LLM Provider Tokens" category in `DEFAULT_SECRET_PATTERNS` and updated the corresponding documentation.
✅ Verification: Ensure tests pass and the new pattern is documented in `docs/SECURITY.md`.

---
*PR created automatically by Jules for task [5704454469265970618](https://jules.google.com/task/5704454469265970618) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive secret-pattern and documentation changes only; no changes to auth flows or data handling beyond improved redaction coverage.
> 
> **Overview**
> Closes a gap in **secret detection** by registering **`gemini_api_key`** (`AIzaSy[A-Za-z0-9_-]{33}`) under **LLM Provider Tokens** in `DEFAULT_SECRET_PATTERNS`, so Gemini keys are blocked/redacted in packets and receipts like other LLM credentials.
> 
> **Docs and tests** are aligned: `docs/SECURITY.md` now lists **46** default patterns (5 LLM), `test_all_default_patterns_exist` asserts `gemini_api_key`, and `.jules/security/sentinel.md` records the finding. Doc examples in `xchecker-receipt` now reference `xchecker_receipt::add_rename_retry_warning` instead of `xchecker_engine::receipt::`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e50599123785f46c9f2bddc9b26912f1bac4985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->