### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing Gemini API keys in secret detection

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,9 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2026-06-18 - Missing Gemini API Keys in Secret Detection
+
+**Vulnerability:** The default secret detection patterns missed Gemini API keys. Given that `xchecker` interacts with Gemini via `gemini-cli`, accidental inclusion of these keys is a high-probability risk.
+**Learning:** Always prioritize secret detection for the specific services' credentials the tool interacts with. Gemini keys (`AIzaSy...`) were missing from the LLM Provider Tokens category.
+**Prevention:** Regularly audit secret detection patterns against the specific integrations used by the tool and its users.

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,14 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -1465,6 +1471,7 @@ mod tests {
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));
         assert!(pattern_ids.contains(&"huggingface_token".to_string()));
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
 
         // Database URLs
         assert!(pattern_ids.contains(&"postgres_url".to_string()));

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The default secret detection patterns missed Gemini API keys (`AIzaSy...`). Given that `xchecker` is an LLM-orchestration tool that integrates with the Google Gemini CLI (`gemini-cli`), accidental inclusion of these keys is a high-probability risk.
🎯 Impact: Accidental leakage of Gemini API keys could result in unauthorized access, resource exhaustion, and financial charges to the user's Google Cloud account.
🔧 Fix: Added the standard Gemini API key regex (`AIzaSy[A-Za-z0-9_-]{33}`) to `DEFAULT_SECRET_PATTERNS` in the `xchecker-redaction` crate under the "LLM Provider Tokens" category. Added tests and regenerated `SECURITY.md` documentation to reflect the new pattern.
✅ Verification: `cargo test -p xchecker-redaction` passes, explicitly asserting the presence of `gemini_api_key`. The `docs/SECURITY.md` accurately lists 5 patterns under "LLM Provider Tokens".

---
*PR created automatically by Jules for task [5461143390273825462](https://jules.google.com/task/5461143390273825462) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive secret-detection pattern and docs only; no change to auth or runtime control flow beyond blocking more key formats.
> 
> **Overview**
> Adds **`gemini_api_key`** (`AIzaSy[A-Za-z0-9_-]{33}`) to the canonical **LLM Provider Tokens** list in `xchecker-redaction`, so Gemini-style Google API keys are caught by the same hard-stop secret scan that blocks other provider credentials before packets reach an LLM or disk.
> 
> Regression coverage now asserts `gemini_api_key` is present in default patterns, **`docs/SECURITY.md`** reflects **46** patterns and **5** LLM provider entries, and **`.jules/security/sentinel.md`** records the gap and remediation for future audits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38af4b1f3a4f062b16a7c68c36f6d99b4e9ac2b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->