### PR TITLE
🎨 Palette: Add discoverability for Home/End keyboard shortcuts in TUI

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [Keyboard Shortcut Discoverability]
+**Learning:** Users may not realize advanced keyboard navigation (like Home/End) exists in TUIs if they are implemented but not advertised in the UI's help text.
+**Action:** Always ensure that all implemented keyboard shortcuts are explicitly advertised in UI help footers to maintain discoverability and accessibility.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added `Home/End: Top/Bottom` text to the footer help string when details are not shown in the TUI workspace view.
🎯 Why: The TUI event loop fully supports `Home` and `End` keys to jump to the first and last spec in the workspace list, but this functionality was completely hidden from the user, reducing discoverability and forcing users to scroll linearly using arrow keys.
📸 Before/After:
*Before:* `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
*After:* `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit`
♿ Accessibility: Improves accessibility by explicitly documenting keyboard alternatives for navigation.

---
*PR created automatically by Jules for task [9549042449626350284](https://jules.google.com/task/9549042449626350284) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only help footer and internal UX notes; no changes to input handling or navigation logic.
> 
> **Overview**
> The workspace list TUI already jumps to the first/last spec on **Home**/**End**; this PR only makes that visible in the **Help** footer when not in the details view by adding `Home/End: Top/Bottom` to the shortcut line.
> 
> A **Keyboard Shortcut Discoverability** note was added to `.jules/ux/palette.md` so future TUIs document implemented shortcuts in help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30a5ef4f180d118e3ed01429b49dcbff76ef33f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->