### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing Gemini API keys in secret detection

### DIFF
--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -163,8 +163,14 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         description: "JSON Web Tokens",
     },
     // =========================================================================
-    // LLM Provider Tokens (4 patterns)
+    // LLM Provider Tokens (5 patterns)
     // =========================================================================
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     SecretPatternDef {
         id: "anthropic_api_key",
         category: "LLM Provider Tokens",
@@ -1461,6 +1467,7 @@ mod tests {
         assert!(pattern_ids.contains(&"jwt_token".to_string()));
 
         // LLM Provider Tokens
+        assert!(pattern_ids.contains(&"gemini_api_key".to_string()));
         assert!(pattern_ids.contains(&"anthropic_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_api_key".to_string()));
         assert!(pattern_ids.contains(&"openai_legacy_key".to_string()));

--- a/crates/xchecker-utils/src/test_support.rs
+++ b/crates/xchecker-utils/src/test_support.rs
@@ -159,6 +159,10 @@ pub fn pypi_token() -> String {
 }
 
 // LLM Provider Tokens
+pub fn gemini_api_key() -> String {
+    format!("AIzaSy{}", make_from(BASE64_URL, 33, 51))
+}
+
 pub fn anthropic_api_key() -> String {
     format!("sk-ant-api03-{}", make_from(BASE64_URL, 95, 47))
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The secret redactor lacked a pattern for Gemini API keys, meaning these secrets would not be redacted and could be leaked in LLM prompts or output logs.
🎯 Impact: A user could accidentally include their Gemini API key in their codebase and the tool would have silently included it in interactions with an LLM.
🔧 Fix: Added the `gemini_api_key` regex `AIzaSy[A-Za-z0-9_-]{33}` to `DEFAULT_SECRET_PATTERNS` under `LLM Provider Tokens`.
✅ Verification: `cargo test --workspace` passes and `docs/SECURITY.md` was correctly regenerated and validated via `regenerate_secret_patterns_docs`.

---
*PR created automatically by Jules for task [166724739273607599](https://jules.google.com/task/166724739273607599) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to secret detection with no auth or data-path changes; overlaps somewhat with the broader `gcp_api_key` pattern but only tightens coverage for LLM-labeled keys.
> 
> **Overview**
> Adds **`gemini_api_key`** to the canonical `DEFAULT_SECRET_PATTERNS` list under **LLM Provider Tokens**, using `AIzaSy[A-Za-z0-9_-]{33}` so Gemini-style Google API keys are caught by the same hard-stop secret scan and redaction path as other LLM provider tokens.
> 
> The change is wired through the usual propagation: **`test_all_default_patterns_exist`** now requires the new pattern id, **`gemini_api_key()`** in test support generates matching sample keys for tests, and **`docs/SECURITY.md`** is updated to **46** default patterns (LLM category **5**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39eb40c3113ddc2b68c1e566c54b27821deaed6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->