### PR TITLE
🎨 Palette: Add missing keyboard shortcut hints to TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [Keyboard Shortcut Hints]
+**Learning:** Users often miss advanced TUI navigation features (like Home/End) if they are not explicitly listed in the help footer.
+**Action:** Always ensure all implemented keyboard shortcuts are advertised in the UI's help footers to maintain discoverability and accessibility.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What:
Added missing `Home/End` and `Esc` shortcut documentations to the UI help footer in the TUI workspace manager (`crates/xchecker-tui/src/lib.rs`).

🎯 Why:
Users often miss advanced TUI navigation features (like Home/End) if they are not explicitly listed in the help footer. These shortcuts were fully implemented but hidden.

📸 Before/After:
**Before:** `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
**After:** `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit`

♿ Accessibility:
Improves interface discoverability for keyboard navigation users.

*(Also added a journal entry in `.jules/ux/palette.md` noting the importance of advertising implemented keyboard shortcuts in TUI applications).*

---
*PR created automatically by Jules for task [8176207467256160712](https://jules.google.com/task/8176207467256160712) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text and internal UX notes only; no changes to key handling or application logic.
> 
> **Overview**
> Updates the workspace TUI **Help** footer on the specs list so it matches shortcuts that were already wired in the event loop: **Home/End** for first/last spec, and **Esc** to quit when not in the details view (alongside **q**).
> 
> Also records a UX palette note to keep implemented keyboard shortcuts visible in TUI help footers for discoverability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50be2237176e139e5322f99d1170c9485d0a94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->