### PR TITLE
⚡ Bolt: Cache Regex compilation in extraction and redaction modules

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+
+## 2024-06-19 - Cache Regex compilations in inner loops
+**Learning:** Instantiating `Regex::new()` repeatedly inside frequently called functions (such as redaction logic running per-log or extraction logic processing documents) creates significant CPU bottleneck due to compilation overhead. While `once_cell` or `lazy_static` were common previously, Rust 1.80's standard library now provides `std::sync::LazyLock` which handles this optimally and natively.
+**Action:** When working on performance optimizations in Rust >= 1.80, always cache compiled regex patterns as `static` variables with `std::sync::LazyLock` when the patterns are fixed and used inside hot loops.

--- a/crates/xchecker-error-redaction/src/lib.rs
+++ b/crates/xchecker-error-redaction/src/lib.rs
@@ -65,6 +65,8 @@
 //! assert!(!redacted.contains("user:password"));
 //! ```
 
+use std::sync::LazyLock;
+
 /// Redact sensitive information from error messages intended for logging.
 ///
 /// Removes API keys, authentication credentials, URLs with embedded credentials,
@@ -80,12 +82,16 @@
 pub fn redact_error_message_for_logging(message: &str) -> String {
     let mut redacted = message.to_string();
 
+    static API_KEY_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"(?:sk-|pk_|api_key|secret|Bearer )[a-zA-Z0-9_-]{20,}").unwrap()
+    });
+    static LONG_KEY_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"[a-zA-Z0-9_-]{32,}").unwrap());
+
     // Redact API keys (long alphanumeric strings with common prefixes)
     // Only redact strings that look like actual API keys (with prefixes like sk-, pk_, etc.)
     // Pattern: prefix followed by at least 20 alphanumeric characters
-    let api_key_regex =
-        regex::Regex::new(r"(?:sk-|pk_|api_key|secret|Bearer )[a-zA-Z0-9_-]{20,}").unwrap();
-    redacted = api_key_regex
+    redacted = API_KEY_REGEX
         .replace_all(&redacted, "[REDACTED_KEY]")
         .to_string();
 
@@ -93,10 +99,9 @@ pub fn redact_error_message_for_logging(message: &str) -> String {
     // Pattern: 32+ alphanumeric/underscore/dash characters that look like a key
     // Only match standalone keys (not embedded in URLs or after @)
     // Manually check boundaries to handle hyphens correctly (which \b doesn't handle well)
-    let long_key_regex = regex::Regex::new(r"[a-zA-Z0-9_-]{32,}").unwrap();
     let mut replacements = Vec::new();
 
-    for mat in long_key_regex.find_iter(&redacted) {
+    for mat in LONG_KEY_REGEX.find_iter(&redacted) {
         let start = mat.start();
         let end = mat.end();
 
@@ -126,18 +131,21 @@ pub fn redact_error_message_for_logging(message: &str) -> String {
         redacted.replace_range(start..end, "[REDACTED_KEY]");
     }
 
+    static URL_WITH_CREDS_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"https?://[a-zA-Z0-9_]+:[^:@\s]+@").unwrap());
+    static PASSWORD_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"(?i)(password|pass|token)").unwrap());
+
     // Redact URLs with embedded credentials first to avoid breaking patterns
     // Pattern: `http://user:pass@host/path` or `https://token123:secret456@host/path`
-    let url_with_creds_regex = regex::Regex::new(r"https?://[a-zA-Z0-9_]+:[^:@\s]+@").unwrap();
-    redacted = url_with_creds_regex
+    redacted = URL_WITH_CREDS_REGEX
         .replace_all(&redacted, "[REDACTED]@")
         .to_string();
 
     // Redact authentication credentials (passwords, tokens)
     if redacted.contains("password") || redacted.contains("token") {
         // Redact common password patterns - simpler regex without character class issues
-        let password_regex = regex::Regex::new(r"(?i)(password|pass|token)").unwrap();
-        redacted = password_regex.replace_all(&redacted, "***").to_string();
+        redacted = PASSWORD_REGEX.replace_all(&redacted, "***").to_string();
     }
 
     // Redact file paths that may contain user-specific data
@@ -178,17 +186,21 @@ pub fn redact_error_message(message: &str) -> String {
 pub fn redact_paths(message: &str) -> String {
     let mut redacted = message.to_string();
 
+    static UNIX_HOME_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"/(?:home|Users)/[^/\\\\]+").unwrap());
+    static WIN_HOME_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"(?i)(?:[A-Za-z]:)?\\\\Users\\\\[^\\\\/]+").unwrap());
+    static DRIVE_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"[A-Za-z]:\\\\").unwrap());
+
     // Redact Unix-style home directories first (e.g., /home/user, /Users/user)
-    let unix_home_regex = regex::Regex::new(r"/(?:home|Users)/[^/\\\\]+").unwrap();
-    redacted = unix_home_regex.replace_all(&redacted, "[HOME]").to_string();
+    redacted = UNIX_HOME_REGEX.replace_all(&redacted, "[HOME]").to_string();
 
     // Redact Windows home directories, optionally with a drive letter
-    let win_home_regex = regex::Regex::new(r"(?i)(?:[A-Za-z]:)?\\\\Users\\\\[^\\\\/]+").unwrap();
-    redacted = win_home_regex.replace_all(&redacted, "[HOME]").to_string();
+    redacted = WIN_HOME_REGEX.replace_all(&redacted, "[HOME]").to_string();
 
     // Redact Windows drive letters (C:\, D:\, etc.)
-    let drive_regex = regex::Regex::new(r"[A-Za-z]:\\\\").unwrap();
-    redacted = drive_regex.replace_all(&redacted, "[DRIVE]").to_string();
+    redacted = DRIVE_REGEX.replace_all(&redacted, "[DRIVE]").to_string();
 
     // Replace path separators to avoid leaking remaining path structure
     redacted = redacted.replace("\\", "[PATH]");

--- a/crates/xchecker-extraction/src/lib.rs
+++ b/crates/xchecker-extraction/src/lib.rs
@@ -13,6 +13,7 @@
 //! Future B3.1 will add structured extraction of full requirement/design objects.
 
 use regex::Regex;
+use std::sync::LazyLock;
 
 /// Summary statistics extracted from a requirements markdown document
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -75,23 +76,29 @@ pub struct TasksSummary {
 pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
     let mut summary = RequirementsSummary::default();
 
+    static USER_STORY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap());
+    static EARS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap()
+    });
+    static NFR_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap()
+    });
+    static REQ_HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap());
+
     // Match user story patterns: **User Story:** or **User Story**:
-    let user_story_re = Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap();
-    summary.user_story_count = user_story_re.find_iter(markdown).count();
+    summary.user_story_count = USER_STORY_RE.find_iter(markdown).count();
 
     // Match EARS-style acceptance criteria: WHEN ... THEN ... SHALL
     // Also match simpler patterns: GIVEN/WHEN/THEN or numbered criteria with SHALL
-    let ears_re =
-        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap();
-    summary.acceptance_criteria_count = ears_re.find_iter(markdown).count();
+    summary.acceptance_criteria_count = EARS_RE.find_iter(markdown).count();
 
     // Match NFR patterns: **NFR-*, NFR-*, **Non-Functional*
-    let nfr_re = Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap();
-    summary.nfr_count = nfr_re.find_iter(markdown).count();
+    summary.nfr_count = NFR_RE.find_iter(markdown).count();
 
     // Match requirement headings: ### Requirement N or ## Requirement N (allow leading whitespace)
-    let req_heading_re = Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap();
-    summary.requirement_count = req_heading_re.find_iter(markdown).count();
+    summary.requirement_count = REQ_HEADING_RE.find_iter(markdown).count();
 
     // If no formal requirement headings, try to count by user story count
     if summary.requirement_count == 0 && summary.user_story_count > 0 {
@@ -121,27 +128,33 @@ pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
 pub fn summarize_design(markdown: &str) -> DesignSummary {
     let mut summary = DesignSummary::default();
 
+    static ARCH_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap()
+    });
+    static COMPONENT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap()
+    });
+    static INTERFACE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap()
+    });
+    static MODEL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap()
+    });
+
     // Check for architecture section (allow leading whitespace from indented doc content)
-    let arch_re = Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap();
-    summary.has_architecture = arch_re.is_match(markdown);
+    summary.has_architecture = ARCH_RE.is_match(markdown);
 
     // Check for mermaid diagrams
     summary.has_diagrams = markdown.contains("```mermaid");
 
     // Count components: ### Component: X or ## Component: X or ### X Component
-    let component_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap();
-    summary.component_count = component_re.find_iter(markdown).count();
+    summary.component_count = COMPONENT_RE.find_iter(markdown).count();
 
     // Count interfaces: ### Interface: X or ## Interface: X or ### X API
-    let interface_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap();
-    summary.interface_count = interface_re.find_iter(markdown).count();
+    summary.interface_count = INTERFACE_RE.find_iter(markdown).count();
 
     // Count data models: ## Data Model or ### Model: or ### Schema:
-    let model_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap();
-    summary.data_model_count = model_re.find_iter(markdown).count();
+    summary.data_model_count = MODEL_RE.find_iter(markdown).count();
 
     summary
 }
@@ -166,21 +179,26 @@ pub fn summarize_design(markdown: &str) -> DesignSummary {
 pub fn summarize_tasks(markdown: &str) -> TasksSummary {
     let mut summary = TasksSummary::default();
 
+    static TASK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap());
+    static SUBTASK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap());
+    static MILESTONE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap());
+    static DEP_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap());
+
     // Count tasks: ## Task N or ### Task N (allow leading whitespace from indented doc content)
-    let task_re = Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap();
-    summary.task_count = task_re.find_iter(markdown).count();
+    summary.task_count = TASK_RE.find_iter(markdown).count();
 
     // Count subtasks: checkbox items - [ ] or - [x]
-    let subtask_re = Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap();
-    summary.subtask_count = subtask_re.find_iter(markdown).count();
+    summary.subtask_count = SUBTASK_RE.find_iter(markdown).count();
 
     // Count milestones: ## Milestone or ### Milestone
-    let milestone_re = Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap();
-    summary.milestone_count = milestone_re.find_iter(markdown).count();
+    summary.milestone_count = MILESTONE_RE.find_iter(markdown).count();
 
     // Count dependencies: "Depends on:" or "Dependencies:"
-    let dep_re = Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap();
-    summary.dependency_count = dep_re.find_iter(markdown).count();
+    summary.dependency_count = DEP_RE.find_iter(markdown).count();
 
     summary
 }


### PR DESCRIPTION
💡 What: Replaced all repeatedly instantiated `Regex::new()` calls inside `xchecker-extraction` and `xchecker-error-redaction` functions with `std::sync::LazyLock` static variables.
🎯 Why: `Regex::new()` is highly CPU intensive because it compiles the expression into an automaton. Instantiating it per function call was a significant bottleneck during processing. Caching ensures they compile once.
📊 Impact: Considerably faster redaction of large logs and faster extraction from markdown documents.
🔬 Measurement: Run integration tests or benchmark markdown ingestion.

---
*PR created automatically by Jules for task [16229089010208523898](https://jules.google.com/task/16229089010208523898) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance refactor; redaction patterns are identical, with only initialization timing changed.
> 
> **Overview**
> **Hot-path regex compilation is removed** in `xchecker-error-redaction` and `xchecker-extraction` by moving every `Regex::new()` that ran on each call into `static` `std::sync::LazyLock` values. Redaction helpers (`redact_error_message_for_logging`, `redact_paths`) and markdown summarizers (`summarize_requirements`, `summarize_design`, `summarize_tasks`) now reuse the same compiled patterns; matching rules and replacement behavior are unchanged.
> 
> A short **Bolt note** in `.jules/bolt.md` records the pattern: prefer `LazyLock` for fixed regexes in Rust ≥ 1.80 instead of recompiling per invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c16b459ef4be6cc1b30c3124e327dd199a96306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->