### PR TITLE
⚡ Bolt: Cache Regex compilation in extraction module

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+
+## 2024-10-30 - Cache Regex compilation in extraction module
+**Learning:** The `xchecker-extraction` module repeatedly compiles `Regex` patterns inside hot extraction functions (like `summarize_requirements`), causing unnecessary CPU overhead. Rust >= 1.80 provides `std::sync::LazyLock` which is perfect for caching these statically without external dependencies like `once_cell`.
+**Action:** Always use `std::sync::LazyLock` to pre-compile and cache regex patterns at the module level when they are used repeatedly.

--- a/crates/xchecker-extraction/src/lib.rs
+++ b/crates/xchecker-extraction/src/lib.rs
@@ -13,6 +13,52 @@
 //! Future B3.1 will add structured extraction of full requirement/design objects.
 
 use regex::Regex;
+use std::sync::LazyLock;
+
+// Optimization: Pre-compile and cache Regex patterns using LazyLock to avoid
+// the CPU overhead of recompiling them inside hot extraction functions.
+
+// Match user story patterns: **User Story:** or **User Story**:
+static USER_STORY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap());
+// Match EARS-style acceptance criteria: WHEN ... THEN ... SHALL
+// Also match simpler patterns: GIVEN/WHEN/THEN or numbered criteria with SHALL
+static EARS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap()
+});
+// Match NFR patterns: **NFR-*, NFR-*, **Non-Functional*
+static NFR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap()
+});
+// Match requirement headings: ### Requirement N or ## Requirement N (allow leading whitespace)
+static REQ_HEADING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap());
+
+// Check for architecture section (allow leading whitespace from indented doc content)
+static ARCH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap());
+// Count components: ### Component: X or ## Component: X or ### X Component
+static COMPONENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap());
+// Count interfaces: ### Interface: X or ## Interface: X or ### X API
+static INTERFACE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap());
+// Count data models: ## Data Model or ### Model: or ### Schema:
+static MODEL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap());
+
+// Count tasks: ## Task N or ### Task N (allow leading whitespace from indented doc content)
+static TASK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap());
+// Count subtasks: checkbox items - [ ] or - [x]
+static SUBTASK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap());
+// Count milestones: ## Milestone or ### Milestone
+static MILESTONE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap());
+// Count dependencies: "Depends on:" or "Dependencies:"
+static DEP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap());
 
 /// Summary statistics extracted from a requirements markdown document
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -73,25 +119,12 @@ pub struct TasksSummary {
 /// ```
 #[must_use]
 pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
-    let mut summary = RequirementsSummary::default();
-
-    // Match user story patterns: **User Story:** or **User Story**:
-    let user_story_re = Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap();
-    summary.user_story_count = user_story_re.find_iter(markdown).count();
-
-    // Match EARS-style acceptance criteria: WHEN ... THEN ... SHALL
-    // Also match simpler patterns: GIVEN/WHEN/THEN or numbered criteria with SHALL
-    let ears_re =
-        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap();
-    summary.acceptance_criteria_count = ears_re.find_iter(markdown).count();
-
-    // Match NFR patterns: **NFR-*, NFR-*, **Non-Functional*
-    let nfr_re = Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap();
-    summary.nfr_count = nfr_re.find_iter(markdown).count();
-
-    // Match requirement headings: ### Requirement N or ## Requirement N (allow leading whitespace)
-    let req_heading_re = Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap();
-    summary.requirement_count = req_heading_re.find_iter(markdown).count();
+    let mut summary = RequirementsSummary {
+        user_story_count: USER_STORY_RE.find_iter(markdown).count(),
+        acceptance_criteria_count: EARS_RE.find_iter(markdown).count(),
+        nfr_count: NFR_RE.find_iter(markdown).count(),
+        requirement_count: REQ_HEADING_RE.find_iter(markdown).count(),
+    };
 
     // If no formal requirement headings, try to count by user story count
     if summary.requirement_count == 0 && summary.user_story_count > 0 {
@@ -119,31 +152,13 @@ pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
 /// ```
 #[must_use]
 pub fn summarize_design(markdown: &str) -> DesignSummary {
-    let mut summary = DesignSummary::default();
-
-    // Check for architecture section (allow leading whitespace from indented doc content)
-    let arch_re = Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap();
-    summary.has_architecture = arch_re.is_match(markdown);
-
-    // Check for mermaid diagrams
-    summary.has_diagrams = markdown.contains("```mermaid");
-
-    // Count components: ### Component: X or ## Component: X or ### X Component
-    let component_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap();
-    summary.component_count = component_re.find_iter(markdown).count();
-
-    // Count interfaces: ### Interface: X or ## Interface: X or ### X API
-    let interface_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap();
-    summary.interface_count = interface_re.find_iter(markdown).count();
-
-    // Count data models: ## Data Model or ### Model: or ### Schema:
-    let model_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap();
-    summary.data_model_count = model_re.find_iter(markdown).count();
-
-    summary
+    DesignSummary {
+        has_architecture: ARCH_RE.is_match(markdown),
+        has_diagrams: markdown.contains("```mermaid"),
+        component_count: COMPONENT_RE.find_iter(markdown).count(),
+        interface_count: INTERFACE_RE.find_iter(markdown).count(),
+        data_model_count: MODEL_RE.find_iter(markdown).count(),
+    }
 }
 
 /// Extract summary metadata from a tasks markdown document
@@ -164,25 +179,12 @@ pub fn summarize_design(markdown: &str) -> DesignSummary {
 /// ```
 #[must_use]
 pub fn summarize_tasks(markdown: &str) -> TasksSummary {
-    let mut summary = TasksSummary::default();
-
-    // Count tasks: ## Task N or ### Task N (allow leading whitespace from indented doc content)
-    let task_re = Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap();
-    summary.task_count = task_re.find_iter(markdown).count();
-
-    // Count subtasks: checkbox items - [ ] or - [x]
-    let subtask_re = Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap();
-    summary.subtask_count = subtask_re.find_iter(markdown).count();
-
-    // Count milestones: ## Milestone or ### Milestone
-    let milestone_re = Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap();
-    summary.milestone_count = milestone_re.find_iter(markdown).count();
-
-    // Count dependencies: "Depends on:" or "Dependencies:"
-    let dep_re = Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap();
-    summary.dependency_count = dep_re.find_iter(markdown).count();
-
-    summary
+    TasksSummary {
+        task_count: TASK_RE.find_iter(markdown).count(),
+        subtask_count: SUBTASK_RE.find_iter(markdown).count(),
+        milestone_count: MILESTONE_RE.find_iter(markdown).count(),
+        dependency_count: DEP_RE.find_iter(markdown).count(),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Added `std::sync::LazyLock` to pre-compile and globally cache `Regex` patterns in the `xchecker-extraction` module, removing the inline regex compilations from `summarize_requirements`, `summarize_design`, and `summarize_tasks`. 
🎯 Why: Iteratively compiling `Regex` patterns on every execution of these hot extraction functions is a significant CPU bottleneck. By caching them statically, we avoid the overhead completely. Rust >= 1.80 supports `LazyLock` natively, avoiding new dependencies.
📊 Impact: Considerably faster metadata extraction with reduced CPU consumption during artifact parsing.
🔬 Measurement: Verified with `cargo test --workspace && cargo test --workspace --doc`.

---
*PR created automatically by Jules for task [4065228862789587212](https://jules.google.com/task/4065228862789587212) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor reuses the same regex strings and counting logic; risk is limited to accidental pattern drift, mitigated by existing unit tests.
> 
> **Overview**
> **Performance-only change** in `xchecker-extraction`: markdown summarizers no longer compile `Regex` on every call.
> 
> All patterns used by `summarize_requirements`, `summarize_design`, and `summarize_tasks` are moved to module-level `static` values behind `std::sync::LazyLock`, so each pattern compiles once on first use. The summarize functions now reference those cached regexes; matching rules and the requirements fallback (inferring `requirement_count` from user stories) are unchanged.
> 
> A short note was added to `.jules/bolt.md` to record this pattern for future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25761947080911fdf4e14e5ed002bf3a7ee37722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->