### PR TITLE
🎨 Palette: Add missing keyboard shortcut hints to TUI footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [Keyboard Discoverability]
+**Learning:** TUI applications often implement keyboard shortcuts like Home/End for navigation, but without explicit advertisement in the UI footers, they remain hidden to users, reducing accessibility.
+**Action:** Always ensure implemented keyboard shortcuts are explicitly advertised in UI help footers to maintain discoverability.

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-runner/src/command_spec.rs
+++ b/crates/xchecker-runner/src/command_spec.rs
@@ -24,7 +24,7 @@ use tokio::process::Command as TokioCommand;
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::CommandSpec;
+/// use xchecker_runner::CommandSpec;
 /// use std::ffi::OsString;
 ///
 /// let cmd = CommandSpec::new("claude")
@@ -58,7 +58,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude");
     /// ```
@@ -84,7 +84,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .arg("--print")
@@ -108,7 +108,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .args(["--print", "--output-format", "json"]);
@@ -132,7 +132,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .cwd("/path/to/workspace");
@@ -153,7 +153,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .env("CLAUDE_API_KEY", "sk-...")
@@ -176,7 +176,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("claude")
     ///     .envs([("DEBUG", "1"), ("VERBOSE", "true")]);
@@ -203,7 +203,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// let cmd = CommandSpec::new("echo")
     ///     .arg("hello")
@@ -236,7 +236,7 @@ impl CommandSpec {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use xchecker_utils::runner::CommandSpec;
+    /// use xchecker_runner::CommandSpec;
     ///
     /// # async fn example() {
     /// let cmd = CommandSpec::new("echo")

--- a/crates/xchecker-runner/src/native.rs
+++ b/crates/xchecker-runner/src/native.rs
@@ -31,7 +31,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{NativeRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{NativeRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = NativeRunner::new();
@@ -51,7 +51,7 @@ impl NativeRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::NativeRunner;
+    /// use xchecker_runner::NativeRunner;
     ///
     /// let runner = NativeRunner::new();
     /// ```

--- a/crates/xchecker-runner/src/process.rs
+++ b/crates/xchecker-runner/src/process.rs
@@ -75,8 +75,8 @@ impl ProcessOutput {
 /// # Example
 ///
 /// ```rust
-/// use xchecker_utils::runner::{ProcessRunner, CommandSpec, ProcessOutput};
-/// use xchecker_utils::error::RunnerError;
+/// use xchecker_runner::{ProcessRunner, CommandSpec, ProcessOutput};
+/// use xchecker_runner::error::RunnerError;
 /// use std::time::Duration;
 ///
 /// struct SimpleRunner;

--- a/crates/xchecker-runner/src/wsl.rs
+++ b/crates/xchecker-runner/src/wsl.rs
@@ -32,7 +32,7 @@ use super::{CommandSpec, ProcessOutput, ProcessRunner};
 /// # Example
 ///
 /// ```rust,no_run
-/// use xchecker_utils::runner::{WslRunner, ProcessRunner, CommandSpec};
+/// use xchecker_runner::{WslRunner, ProcessRunner, CommandSpec};
 /// use std::time::Duration;
 ///
 /// let runner = WslRunner::new();
@@ -55,7 +55,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::new();
     /// ```
@@ -73,7 +73,7 @@ impl WslRunner {
     /// # Example
     ///
     /// ```rust
-    /// use xchecker_utils::runner::WslRunner;
+    /// use xchecker_runner::WslRunner;
     ///
     /// let runner = WslRunner::with_distro("Ubuntu-22.04");
     /// ```

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What:
Added explicit text ("Home/End: Top/Bottom") to the TUI help footer to explicitly advertise the Home and End keyboard shortcuts for rapid navigation. Also fixed broken rustdoc tests across `xchecker-receipt` and `xchecker-runner`.

🎯 Why:
The TUI implemented Home and End functionality for fast top/bottom scrolling, but this was entirely hidden from the user. Explicitly listing these shortcuts reduces cognitive load and improves accessibility for keyboard-reliant users. The doc test fixes were necessary to ensure the workspace passes all CI checks cleanly.

📸 Before/After:
Before: `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
After: `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit`

♿ Accessibility:
Directly improves keyboard discoverability by exposing hidden navigation shortcuts, making the interface more intuitive for screen reader and keyboard-only users who cannot easily scroll visually.

---
*PR created automatically by Jules for task [17465079057670848784](https://jules.google.com/task/17465079057670848784) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are help text, documentation examples, and a design note—no execution or security logic.
> 
> **Overview**
> The workspace TUI **help footer** now lists **Home/End: Top/Bottom** on the main specs list view so existing first/last navigation keys are visible in the UI.
> 
> A **Jules UX palette** note was added to document advertising keyboard shortcuts in TUI footers.
> 
> **Rustdoc examples** were updated so doctest paths match current crates: `xchecker_receipt::add_rename_retry_warning` in `xchecker-receipt`, and `xchecker_runner::` (plus `xchecker_runner::error::RunnerError`) instead of `xchecker_utils::runner::` across `xchecker-runner` docs. No runtime behavior changes beyond the footer text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d174f6bf59067b43c147f6cf5d497c5cf57bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->