### PR TITLE
🎨 Palette: Add keyboard shortcut hints to TUI footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-06-21 - [TUI Keyboard Discoverability]
+**Learning:** Users often don't know about helpful keyboard shortcuts (like `Home` and `End`) if they aren't explicitly advertised in the UI. Also, `Esc` behavior can be context-dependent.
+**Action:** Always ensure any keyboard shortcuts implemented in the event loop are explicitly advertised in the UI's help footers to maintain discoverability and accessibility.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added explicitly advertised keyboard shortcuts (`Home`, `End`, and `Esc`) to the main list view footer in the TUI application.
🎯 Why: Users often do not discover helpful keyboard shortcuts if they are not visible in the UI. Also, the behavior of the `Esc` key is context-dependent, which can be confusing without visual cues.
📸 Before/After: N/A (Text-based change in terminal)
♿ Accessibility: Improves discoverability and keyboard accessibility for users relying on non-mouse navigation.

---
*PR created automatically by Jules for task [4548049562669702324](https://jules.google.com/task/4548049562669702324) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to help text and internal UX notes; no behavior or logic changes.
> 
> **Overview**
> Updates the **main list** help footer so it matches shortcuts that were already wired in the event loop but not shown to users.
> 
> The footer now calls out **`Home`/`End`** for jumping to the first/last spec and **`Esc`** alongside **`q`** for quitting from the list (details view help is unchanged). A **palette** entry records the rule: advertise TUI shortcuts in help footers for discoverability and context-dependent keys like `Esc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52564239680dcb478d516b9adae2b6f2bf39d399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->