### PR TITLE
🛡️ Sentinel: Add Gemini API key detection and fix overlapping redaction bug

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,9 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2026-01-25 - Overlapping Secret Pattern Overwrites
+
+**Vulnerability:** The secret redactor's replacement loop was processing replacements sequentially using original file indexes but substituting entire line blocks. When multiple secrets existed on the same line (e.g., overlapping API keys), the second replacement would overwrite the first redaction with unredacted text and panic due to invalid offsets.
+**Learning:** Text replacements that alter line length invalidate original string offsets. Replacing the entire line based on original file indexes causes subsequent replacements on that line to corrupt output or panic.
+**Prevention:** Always perform multiple substring replacements per line from right-to-left (reverse index order) to preserve earlier string offsets, and track modified lines individually before replacing them in the main buffer.

--- a/crates/xchecker-redaction/src/lib.rs
+++ b/crates/xchecker-redaction/src/lib.rs
@@ -189,6 +189,12 @@ pub static DEFAULT_SECRET_PATTERNS: &[SecretPatternDef] = &[
         regex: r"hf_[A-Za-z0-9]{34}",
         description: "Hugging Face access tokens",
     },
+    SecretPatternDef {
+        id: "gemini_api_key",
+        category: "LLM Provider Tokens",
+        regex: r"AIzaSy[A-Za-z0-9_-]{33}",
+        description: "Gemini API keys",
+    },
     // =========================================================================
     // Database Connection URLs (5 patterns)
     // =========================================================================
@@ -667,26 +673,41 @@ impl SecretRedactor {
         let lines: Vec<&str> = content.lines().collect();
 
         // Replace secrets with redaction markers
+        let mut current_line_idx = usize::MAX;
+        let mut current_redacted_line = String::new();
+        // Keep track of the start index of the last replacement on the current line.
+        // Since we process right-to-left, we should only replace if `end <= last_replaced_start`.
+        // If it overlaps, we skip it to avoid panicking on modified string indices.
+        let mut last_replaced_start = usize::MAX;
+
         for secret_match in &sorted_matches {
-            if let Some(line) = lines.get(secret_match.line_number - 1) {
+            let line_idx = secret_match.line_number - 1;
+            if let Some(original_line) = lines.get(line_idx) {
+                if current_line_idx != line_idx {
+                    if current_line_idx != usize::MAX {
+                        let line_start = content.lines().take(current_line_idx).map(|l| l.len() + 1).sum::<usize>();
+                        let line_end = line_start + lines[current_line_idx].len();
+                        redacted_content.replace_range(line_start..line_end, &current_redacted_line);
+                    }
+                    current_line_idx = line_idx;
+                    current_redacted_line = original_line.to_string();
+                    last_replaced_start = usize::MAX;
+                }
+
                 let (start, end) = secret_match.column_range;
-                if start < line.len() && end <= line.len() {
-                    let before = &line[..start];
-                    let after = &line[end..];
-                    let redacted_line =
-                        format!("{}[REDACTED:{}]{}", before, secret_match.pattern_id, after);
-
-                    // Replace the line in the content
-                    let line_start = content
-                        .lines()
-                        .take(secret_match.line_number - 1)
-                        .map(|l| l.len() + 1) // +1 for newline
-                        .sum::<usize>();
-                    let line_end = line_start + line.len();
-
-                    redacted_content.replace_range(line_start..line_end, &redacted_line);
+                // Only replace if it doesn't overlap with a replacement we already made to the right
+                if start < original_line.len() && end <= original_line.len() && end <= last_replaced_start {
+                    let marker = format!("[REDACTED:{}]", secret_match.pattern_id);
+                    current_redacted_line.replace_range(start..end, &marker);
+                    last_replaced_start = start;
                 }
             }
+        }
+
+        if current_line_idx != usize::MAX {
+            let line_start = content.lines().take(current_line_idx).map(|l| l.len() + 1).sum::<usize>();
+            let line_end = line_start + lines[current_line_idx].len();
+            redacted_content.replace_range(line_start..line_end, &current_redacted_line);
         }
 
         Ok(RedactionResult {
@@ -1131,6 +1152,23 @@ mod tests {
         let result = redactor.redact_content(&content, "test.txt").unwrap();
         assert!(result.has_secrets);
         assert!(result.content.contains("[REDACTED:huggingface_token]"));
+        assert!(!result.content.contains(token));
+    }
+
+    #[test]
+    fn test_gemini_api_key_detection() {
+        let redactor = SecretRedactor::new().unwrap();
+        // Gemini API keys start with AIzaSy followed by 33 characters
+        let token = "AIzaSyA_B-C_D-E_F-G_H-I_J-K_L-M_N-O_P_Q";
+        let content = format!("export GEMINI_API_KEY={}", token);
+
+        let matches = redactor.scan_for_secrets(&content, "test.txt").unwrap();
+        assert!(matches.iter().any(|m| m.pattern_id == "gemini_api_key"));
+
+        let result = redactor.redact_content(&content, "test.txt").unwrap();
+        assert!(result.has_secrets);
+        // Note: It might be redacted as [REDACTED:gcp_api_key] if they overlap and GCP is processed first
+        assert!(result.content.contains("[REDACTED:gemini_api_key]") || result.content.contains("[REDACTED:gcp_api_key]"));
         assert!(!result.content.contains(token));
     }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ The SecretRedactor component detects and blocks secrets before they reach Claude
 ### Default Secret Patterns
 
 <!-- BEGIN GENERATED:DEFAULT_SECRET_PATTERNS -->
-xchecker includes **45 default secret patterns** across 8 categories.
+xchecker includes **46 default secret patterns** across 8 categories.
 
 #### AWS Credentials (5 patterns)
 
@@ -70,11 +70,12 @@ xchecker includes **45 default secret patterns** across 8 categories.
 | `jwt_token` | `eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]*` | JSON Web Tokens |
 | `oauth_token` | `(?i)(?:access_token\|refresh_token)[=:][A-Za-z0-9._-]{20,}` | OAuth tokens |
 
-#### LLM Provider Tokens (4 patterns)
+#### LLM Provider Tokens (5 patterns)
 
 | Pattern ID | Regex | Description |
 |------------|-------|-------------|
 | `anthropic_api_key` | `sk-ant-api03-[A-Za-z0-9_-]{20,}` | Anthropic API keys |
+| `gemini_api_key` | `AIzaSy[A-Za-z0-9_-]{33}` | Gemini API keys |
 | `huggingface_token` | `hf_[A-Za-z0-9]{34}` | Hugging Face access tokens |
 | `openai_api_key` | `sk-(?:proj\|org)-[A-Za-z0-9_-]{20,}` | OpenAI Project/Org API keys |
 | `openai_legacy_key` | `sk-[A-Za-z0-9]{48}` | OpenAI Legacy API keys |


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing detection for Gemini API keys, allowing them to leak into packets unredacted. Additionally, overlapping secrets on the same line caused `SecretRedactor` to panic or overwrite prior redactions, leading to service disruption or secret exposure.
🎯 Impact: Prevents Gemini API keys from leaking to Claude contexts. Fixes critical stability/leak issue in secret redaction when multiple secrets occur on the same line.
🔧 Fix: Added Gemini pattern `AIzaSy...`. Overhauled the `redact_content` logic to safely process inline string replacements from right-to-left, tracking line indices dynamically.
✅ Verification: Passes new `test_gemini_api_key_detection` which checks for both detection and safe overlapping interaction with the generic GCP key pattern.

---
*PR created automatically by Jules for task [3659198804102975920](https://jules.google.com/task/3659198804102975920) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes secret redaction on the egress path to LLM packets; bugs could leak credentials or crash scanning, though the fix targets a known exposure/panic case.
> 
> **Overview**
> Adds a **`gemini_api_key`** default pattern (`AIzaSy…`) so Gemini credentials are detected alongside other LLM provider tokens, with **`docs/SECURITY.md`** updated to **46** patterns.
> 
> **`redact_content`** no longer swaps whole lines per match using stale byte offsets. It builds each line in a buffer, applies replacements **right-to-left** on **original** column ranges, skips overlapping matches (e.g. Gemini vs **`gcp_api_key`**), then writes the line back once—avoiding panics and accidental restoration of raw secrets when multiple matches share a line.
> 
> Sentinel notes the overlapping-redaction incident; regression coverage includes **`test_gemini_api_key_detection`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c640818d7c8c286bc9d2baa0e55a7b6c852e8955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->