### PR TITLE
⚡ Bolt: Cache Regex compilation in extraction module

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-23 - RegexSet Pre-filtering for Secret Detection
 **Learning:** Iterating through 40+ complex regex patterns for secret detection on every file is a significant CPU bottleneck. The `regex::RegexSet` type allows compiling multiple patterns into a single automaton that can check for *any* match in a single pass (roughly equivalent to `pattern1|pattern2|...`).
 **Action:** When performing multi-pattern matching where the negative case (no match) is common, always use `RegexSet` to pre-filter content before running individual regexes for extraction/replacement. This reduced redaction overhead significantly.
+## 2024-05-24 - Cache Regex Compilation in Extraction Module
+**Learning:** Compiling regexes inside functions that are called frequently causes a significant CPU bottleneck due to repeated compilation. Using `std::sync::LazyLock` to cache compiled regexes as statics eliminates this overhead.
+**Action:** Always cache compiled regexes using `LazyLock` when defining them inside frequently called functions.

--- a/crates/xchecker-extraction/src/lib.rs
+++ b/crates/xchecker-extraction/src/lib.rs
@@ -76,22 +76,22 @@ pub fn summarize_requirements(markdown: &str) -> RequirementsSummary {
     let mut summary = RequirementsSummary::default();
 
     // Match user story patterns: **User Story:** or **User Story**:
-    let user_story_re = Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap();
-    summary.user_story_count = user_story_re.find_iter(markdown).count();
+    static USER_STORY_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)^\s*\*\*User\s+Story[:\*]").unwrap());
+    summary.user_story_count = USER_STORY_RE.find_iter(markdown).count();
 
     // Match EARS-style acceptance criteria: WHEN ... THEN ... SHALL
     // Also match simpler patterns: GIVEN/WHEN/THEN or numbered criteria with SHALL
-    let ears_re =
-        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap();
-    summary.acceptance_criteria_count = ears_re.find_iter(markdown).count();
+    static EARS_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(||
+        Regex::new(r"(?im)(WHEN\s+.+\s+THEN\s+.+\s+SHALL|GIVEN\s+.+\s+WHEN\s+.+\s+THEN)").unwrap());
+    summary.acceptance_criteria_count = EARS_RE.find_iter(markdown).count();
 
     // Match NFR patterns: **NFR-*, NFR-*, **Non-Functional*
-    let nfr_re = Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap();
-    summary.nfr_count = nfr_re.find_iter(markdown).count();
+    static NFR_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)(^\s*\*\*NFR[-\s]|\bNFR-\w+\b|^\s*\*\*Non-Functional)").unwrap());
+    summary.nfr_count = NFR_RE.find_iter(markdown).count();
 
     // Match requirement headings: ### Requirement N or ## Requirement N (allow leading whitespace)
-    let req_heading_re = Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap();
-    summary.requirement_count = req_heading_re.find_iter(markdown).count();
+    static REQ_HEADING_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Requirement\s+\d+").unwrap());
+    summary.requirement_count = REQ_HEADING_RE.find_iter(markdown).count();
 
     // If no formal requirement headings, try to count by user story count
     if summary.requirement_count == 0 && summary.user_story_count > 0 {
@@ -122,26 +122,26 @@ pub fn summarize_design(markdown: &str) -> DesignSummary {
     let mut summary = DesignSummary::default();
 
     // Check for architecture section (allow leading whitespace from indented doc content)
-    let arch_re = Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap();
-    summary.has_architecture = arch_re.is_match(markdown);
+    static ARCH_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)^\s*#{1,3}\s+(Architecture|System\s+Architecture)").unwrap());
+    summary.has_architecture = ARCH_RE.is_match(markdown);
 
     // Check for mermaid diagrams
     summary.has_diagrams = markdown.contains("```mermaid");
 
     // Count components: ### Component: X or ## Component: X or ### X Component
-    let component_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap();
-    summary.component_count = component_re.find_iter(markdown).count();
+    static COMPONENT_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(||
+        Regex::new(r"(?im)^\s*#{2,3}\s+(Component[:\s]|[A-Z]\w+\s+Component)").unwrap());
+    summary.component_count = COMPONENT_RE.find_iter(markdown).count();
 
     // Count interfaces: ### Interface: X or ## Interface: X or ### X API
-    let interface_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap();
-    summary.interface_count = interface_re.find_iter(markdown).count();
+    static INTERFACE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(||
+        Regex::new(r"(?im)^\s*#{2,3}\s+(Interface[:\s]|[A-Z]\w+\s+(API|Interface))").unwrap());
+    summary.interface_count = INTERFACE_RE.find_iter(markdown).count();
 
     // Count data models: ## Data Model or ### Model: or ### Schema:
-    let model_re =
-        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap();
-    summary.data_model_count = model_re.find_iter(markdown).count();
+    static MODEL_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(||
+        Regex::new(r"(?im)^\s*#{2,3}\s+(Data\s+Model|Model[:\s]|Schema[:\s]|Entity[:\s])").unwrap());
+    summary.data_model_count = MODEL_RE.find_iter(markdown).count();
 
     summary
 }
@@ -167,20 +167,20 @@ pub fn summarize_tasks(markdown: &str) -> TasksSummary {
     let mut summary = TasksSummary::default();
 
     // Count tasks: ## Task N or ### Task N (allow leading whitespace from indented doc content)
-    let task_re = Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap();
-    summary.task_count = task_re.find_iter(markdown).count();
+    static TASK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Task\s+\d+").unwrap());
+    summary.task_count = TASK_RE.find_iter(markdown).count();
 
     // Count subtasks: checkbox items - [ ] or - [x]
-    let subtask_re = Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap();
-    summary.subtask_count = subtask_re.find_iter(markdown).count();
+    static SUBTASK_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?m)^\s*[-*]\s+\[[ xX]\]").unwrap());
+    summary.subtask_count = SUBTASK_RE.find_iter(markdown).count();
 
     // Count milestones: ## Milestone or ### Milestone
-    let milestone_re = Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap();
-    summary.milestone_count = milestone_re.find_iter(markdown).count();
+    static MILESTONE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)^\s*#{2,3}\s+Milestone").unwrap());
+    summary.milestone_count = MILESTONE_RE.find_iter(markdown).count();
 
     // Count dependencies: "Depends on:" or "Dependencies:"
-    let dep_re = Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap();
-    summary.dependency_count = dep_re.find_iter(markdown).count();
+    static DEP_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new(r"(?im)(Depends\s+on:|Dependencies:)").unwrap());
+    summary.dependency_count = DEP_RE.find_iter(markdown).count();
 
     summary
 }


### PR DESCRIPTION
**💡 What:** Move regex compilation in `crates/xchecker-extraction/src/lib.rs` into `std::sync::LazyLock` statics.
**🎯 Why:** Repeatedly compiling regexes on every invocation of summary functions causes a performance bottleneck.
**📊 Impact:** Avoids expensive runtime recompilation, significantly speeding up markdown analysis for requirements, designs, and tasks.
**🔬 Measurement:** Verified that the `xchecker-extraction` unit tests and workspace tests pass perfectly with the refactored logic.

---
*PR created automatically by Jules for task [11301150557133786796](https://jules.google.com/task/11301150557133786796) started by @EffortlessSteven*