### PR TITLE
🎨 Palette: Add missing Home/End and Esc keyboard shortcuts to TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-06-25 - [TUI Keyboard Discoverability]
+**Learning:** Terminal UI users often assume only advertised keyboard shortcuts exist, even when standard keys like Home, End, or Esc are fully implemented in the event loop.
+**Action:** When developing or modifying TUI applications, always ensure that all functional keyboard shortcuts are explicitly documented in the on-screen help footer to maintain discoverability and accessibility.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What:
Added `Home/End` (Top/Bottom) and `Esc` (Quit) keyboard shortcut hints to the main TUI screen's help footer.

🎯 Why:
The keybindings were fully implemented and functional in the `run_app` event loop (e.g., Home jumps to the top of the list, End jumps to the bottom), but users had no way of knowing they existed because the help footer only advertised `↑/k`, `↓/j`, `Enter`, and `q`.

📸 Before/After:
**Before:** `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
**After:**  `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit`

♿ Accessibility:
Improves discoverability of keyboard-only navigation options. Users relying on keyboards or assistive devices now explicitly know they can rapidly jump through long lists of specs without repeated arrow key presses.

---
*PR created automatically by Jules for task [14683999990579184469](https://jules.google.com/task/14683999990579184469) started by @EffortlessSteven*