### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in file reading

### DIFF
--- a/.jules/security/sentinel.md
+++ b/.jules/security/sentinel.md
@@ -145,3 +145,8 @@
 
 **Files Changed:**
 - `crates/xchecker-utils/src/redaction.rs`
+
+## 2026-01-25 - TOCTOU Vulnerability in File Reading
+**Vulnerability:** A TOCTOU (Time-Of-Check to Time-Of-Use) race condition existed in `PacketBuilder::build` where the file size was checked against a budget limit using `fs::metadata` before the content was read via `fs::read_to_string` without a limit. This could result in unbounded memory allocation if the file grew after the check, leading to an OOM DoS attack.
+**Learning:** Using `fs::read_to_string` on potentially untrusted or concurrently modified files can lead to memory exhaustion. File size checks before reading are insufficient against race conditions unless a hard limit is enforced during the actual read operation.
+**Prevention:** Use `File::open` and `std::io::Read::take(limit)` to enforce a hard bound on the number of bytes read into memory, preventing OOM even if the file changes after the metadata check.

--- a/crates/xchecker-packet/src/builder.rs
+++ b/crates/xchecker-packet/src/builder.rs
@@ -476,9 +476,22 @@ fn process_candidate_file(
         return Ok(None);
     }
 
-    // Read content
-    let content = fs::read_to_string(&candidate.path)
+    // Read content safely with a hard limit to prevent TOCTOU DoS
+    let file = fs::File::open(&candidate.path)
+        .with_context(|| format!("Failed to open file: {}", candidate.path))?;
+    let mut content = String::with_capacity(metadata.len() as usize);
+    use std::io::Read;
+    file.take(max_file_size + 1)
+        .read_to_string(&mut content)
         .with_context(|| format!("Failed to read file: {}", candidate.path))?;
+
+    if content.len() > max_file_size as usize {
+        return Err(anyhow::anyhow!(
+            "File {} grew beyond the size limit ({} bytes) during reading. Possible TOCTOU attack.",
+            candidate.path,
+            max_file_size
+        ));
+    }
 
     // Scan for secrets immediately after reading
     if redactor.has_secrets(&content, candidate.path.as_ref())? {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A TOCTOU (Time-Of-Check to Time-Of-Use) race condition existed in `PacketBuilder::build` where the file size was checked against a budget limit using `fs::metadata` before the content was read via `fs::read_to_string` without a limit. This could result in unbounded memory allocation if a file grew rapidly or was replaced by an infinite stream (like `/dev/zero`) after the check, leading to an Out-Of-Memory (OOM) Denial of Service (DoS) attack.
🎯 Impact: An attacker could cause the application to crash by exhausting available memory.
🔧 Fix: Used `File::open` and `std::io::Read::take(max_file_size + 1).read_to_string(...)` to enforce a hard bound on the number of bytes read into memory, preventing OOM even if the file changes after the metadata check.
✅ Verification: Tested via unit tests and integration tests using `cargo test --workspace`. Verified the fix correctly compiles and catches oversized streams safely.

---
*PR created automatically by Jules for task [12362901914321117324](https://jules.google.com/task/12362901914321117324) started by @EffortlessSteven*