### PR TITLE
🎨 Palette: Add Home/End keyboard shortcut hints to TUI footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-06-28 - [Discoverable TUI Shortcuts]
+**Learning:** Keyboard shortcuts implemented in the TUI event loop (like Home/End) are invisible to users if not explicitly advertised in the UI.
+**Action:** Always document all supported navigational keyboard shortcuts in the TUI's help footer to maintain discoverability and accessibility.

--- a/crates/xchecker-receipt/src/writer.rs
+++ b/crates/xchecker-receipt/src/writer.rs
@@ -126,12 +126,12 @@ impl ReceiptManager {
 ///
 /// ```
 /// let mut warnings = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings, Some(3));
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings, Some(3));
 /// assert_eq!(warnings.len(), 1);
 /// assert_eq!(warnings[0], "rename_retry_count: 3");
 ///
 /// let mut warnings2 = vec![];
-/// xchecker_engine::receipt::add_rename_retry_warning(&mut warnings2, None);
+/// xchecker_receipt::add_rename_retry_warning(&mut warnings2, None);
 /// assert_eq!(warnings2.len(), 0);
 /// ```
 #[allow(dead_code)] // Receipt utility for tracking atomic write retries

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added documentation for the existing `Home` and `End` keyboard shortcuts to the TUI's help footer text.
🎯 Why: These navigational shortcuts were already fully implemented in the event loop but were invisible to users because they were not mentioned in the footer's help string.
📸 Before/After: 
Before: `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
After: `↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  q: Quit`
♿ Accessibility: Improves accessibility and discoverability of non-mouse navigation options, allowing users to quickly jump to the top or bottom of lists.

---
*PR created automatically by Jules for task [16810922750091146760](https://jules.google.com/task/16810922750091146760) started by @EffortlessSteven*