### PR TITLE
🎨 Palette: Add missing keyboard shortcuts to TUI help footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2026-01-24 - [Discoverable TUI Shortcuts]
+**Learning:** TUI applications often implement keyboard shortcuts in the event loop (like Home/End or Esc) without advertising them in the UI, leading to poor discoverability and accessibility.
+**Action:** Always ensure all implemented keyboard shortcuts are explicitly documented in the UI's help footers to maintain discoverability.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -680,7 +680,7 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
         "Esc: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Home/End: Top/Bottom  Enter: Details  Esc/q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added explicitly supported `Home/End` and `Esc` keyboard shortcuts to the TUI's footer help text.
🎯 Why: TUI applications often implement keyboard shortcuts in the event loop (like `Home/End` for list navigation or `Esc` to quit) without advertising them in the UI, leading to poor discoverability and a sub-par user experience.
📸 Before/After: N/A - text-only change
♿ Accessibility: Improves accessibility and discoverability by explicitly advertising keyboard-only navigation options to users relying on non-mouse interactions.

---
*PR created automatically by Jules for task [5716667224849203518](https://jules.google.com/task/5716667224849203518) started by @EffortlessSteven*