### PR TITLE
🎨 Palette: Improve TUI navigation UX with Left/Right master-detail flow

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - TUI Keybindings UX Learning
+**Learning:** Terminal/TUI applications benefit immensely from adopting common navigation keybindings (Vim-like h/l, g/G, and standard directional arrow keys) because users have strong muscle memory for these interaction models. Exposing hidden or undocumented features (like Home/End) directly in the help UI significantly improves discoverability.
+**Action:** When working on TUI crates or CLI tools in Rust, verify that directional movement maps naturally to master-detail UI paradigms (Right/l to drill down, Left/h to back out) and explicitly document all available navigation mappings in the footer/help UI.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -317,21 +317,27 @@ where
                         app.select_next();
                     }
                 }
-                KeyCode::Home => {
+                KeyCode::Home | KeyCode::Char('g') => {
                     if !app.show_details {
                         app.select_first();
                     }
                 }
-                KeyCode::End => {
+                KeyCode::End | KeyCode::Char('G') => {
                     if !app.show_details {
                         app.select_last();
                     }
                 }
-                KeyCode::Enter => app.toggle_details(),
-                KeyCode::Esc => {
+                KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => {
+                    if key.code == KeyCode::Enter {
+                        app.toggle_details();
+                    } else if !app.show_details {
+                        app.show_details = true;
+                    }
+                }
+                KeyCode::Esc | KeyCode::Left | KeyCode::Char('h') => {
                     if app.show_details {
                         app.show_details = false;
-                    } else {
+                    } else if key.code == KeyCode::Esc {
                         return Ok(());
                     }
                 }
@@ -678,9 +684,9 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
 /// Render the footer with help text
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     let help_text = if app.show_details {
-        "Esc: Back  q: Quit"
+        "Esc/←/h: Back  q: Quit"
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        "↑/k: Up  ↓/j: Down  Enter/→/l: Details  Home/End/g/G: First/Last  q: Quit"
     };
 
     let footer = Paragraph::new(help_text)


### PR DESCRIPTION
💡 What: Added Vim-like (`h`, `l`, `g`, `G`) and directional (`Left`, `Right`) navigation to the `xchecker-tui` crate, mapping them intuitively to a master-detail flow (Right/l to open details, Left/h to close). Updated the footer to expose these features alongside previously hidden `Home/End` navigation.

🎯 Why: Users of terminal applications have strong muscle memory for standard directional and Vim-like navigation. Relying solely on `Enter` and `Esc` for master-detail traversal requires more cognitive load than simply pressing `Right` to dive in and `Left` to back out. Exposing `Home`/`End` in the UI improves discoverability.

📸 Before/After: 
Before: Help text read `↑/k: Up  ↓/j: Down  Enter: Details  q: Quit`
After: Help text reads `↑/k: Up  ↓/j: Down  Enter/→/l: Details  Home/End/g/G: First/Last  q: Quit`

♿ Accessibility: Ensures that keyboard users have multiple, predictable ways to navigate the TUI list and detail views, supporting both standard arrow-key users and power users with Vim bindings.

---
*PR created automatically by Jules for task [12604461223991906137](https://jules.google.com/task/12604461223991906137) started by @EffortlessSteven*