### PR TITLE
🎨 Palette: Add HighlightSpacing to TUI specs list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2026-07-02 - Added continuous highlight spacing to TUI List
+
+**Learning:** When using Ratatui's `List` widget with a highlight symbol like `"▶ "`, selecting an item shifts its content right. Moving the selection causes the new item to shift and the old item to shift back, creating a jarring, "jumping" UX during keyboard navigation. Ratatui's `HighlightSpacing::Always` prevents this by preserving space for the symbol on unselected items.
+
+**Action:** Whenever building or modifying a Ratatui `List` that uses a `highlight_symbol`, always configure `.highlight_spacing(HighlightSpacing::Always)` to ensure smooth keyboard navigation without horizontal layout jumping.

--- a/crates/xchecker-tui/Cargo.toml
+++ b/crates/xchecker-tui/Cargo.toml
@@ -19,7 +19,7 @@ xchecker-utils = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 crossterm = { workspace = true }
-ratatui = { workspace = true }
+ratatui = { workspace = true, features = ["all-widgets"] }
 
 [dev-dependencies]
 # For testing

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -20,7 +20,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::io;
 use std::path::Path;
@@ -531,7 +531,8 @@ fn render_specs_list(f: &mut Frame, app: &TuiApp, area: Rect) {
                 .bg(Color::DarkGray)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol("▶ ");
+        .highlight_symbol("▶ ")
+        .highlight_spacing(HighlightSpacing::Always);
 
     f.render_stateful_widget(list, area, &mut app.list_state.clone());
 }


### PR DESCRIPTION
💡 What: Added `HighlightSpacing::Always` to the Ratatui `List` widget in the TUI specs list.
🎯 Why: When using a highlight symbol like `"▶ "`, selecting an item shifts its content to the right to make room for the symbol. When navigating with the keyboard, this causes the new item to shift right and the old item to shift back left, creating a jarring, "jumping" visual experience. `HighlightSpacing::Always` preserves the space for the symbol on unselected items, ensuring a smooth, stable layout during navigation.
📸 Before/After: Before, navigating the list caused horizontal jumping. After, the text remains horizontally aligned while the `"▶ "` cursor moves up and down smoothly.
♿ Accessibility: Improves keyboard navigation experience by removing disorienting layout shifts for keyboard-focused users.

---
*PR created automatically by Jules for task [12951420324866526875](https://jules.google.com/task/12951420324866526875) started by @EffortlessSteven*