### PR TITLE
🎨 Palette: Improve keyboard shortcut hints in TUI footer

### DIFF
--- a/.jules/ux/palette.md
+++ b/.jules/ux/palette.md
@@ -10,3 +10,7 @@
 
 **Learning:** Dense text outputs in CLI tools are hard to scan. Users miss the overall status when it's just another line of text.
 **Action:** Use emojis (e.g., 🩺) for immediate context recognition and horizontal separators (e.g., ─────) to visually distinguish the summary/result from the detailed logs.
+
+## 2024-05-19 - Keyboard Shortcut Hints in TUI Footer
+**Learning:** Adding explicit keyboard shortcuts (like Home/End) to help text makes CLI/TUI tools much more discoverable and accessible for keyboard users.
+**Action:** Always document full keyboard navigation shortcuts in TUI footers or help menus.

--- a/crates/xchecker-tui/src/lib.rs
+++ b/crates/xchecker-tui/src/lib.rs
@@ -677,13 +677,32 @@ fn render_details(f: &mut Frame, app: &TuiApp, area: Rect) {
 
 /// Render the footer with help text
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let help_text = if app.show_details {
-        "Esc: Back  q: Quit"
+    let key_style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let help_line = if app.show_details {
+        Line::from(vec![
+            Span::styled("Esc", key_style),
+            Span::raw(": Back  "),
+            Span::styled("q", key_style),
+            Span::raw(": Quit"),
+        ])
     } else {
-        "↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"
+        Line::from(vec![
+            Span::styled("↑/k", key_style),
+            Span::raw(": Up  "),
+            Span::styled("↓/j", key_style),
+            Span::raw(": Down  "),
+            Span::styled("Home/End", key_style),
+            Span::raw(": First/Last  "),
+            Span::styled("Enter", key_style),
+            Span::raw(": Details  "),
+            Span::styled("q", key_style),
+            Span::raw(": Quit"),
+        ])
     };
 
-    let footer = Paragraph::new(help_text)
+    let footer = Paragraph::new(help_line)
         .style(Style::default().fg(Color::DarkGray))
         .block(Block::default().borders(Borders::ALL).title(" Help "));
     f.render_widget(footer, area);


### PR DESCRIPTION
💡 What: Added explicit keyboard shortcut hints (like Home/End for First/Last) and color highlighting (Cyan and Bold) for key references in the TUI footer.
🎯 Why: To make the CLI/TUI tools more discoverable and readable, specifically aiding users relying on keyboard navigation. Naive plain-text footers make it hard to quickly scan which keys to press.
📸 Before/After: Before, it was a plain string `"↑/k: Up  ↓/j: Down  Enter: Details  q: Quit"`. Now, it correctly uses `Line` and `Span` to format the keys distinctly from the actions and includes `"Home/End: First/Last"`.
♿ Accessibility: Improves cognitive accessibility and discoverability by visually separating keys from actions and surfacing full navigation controls.

---
*PR created automatically by Jules for task [5948914264502480814](https://jules.google.com/task/5948914264502480814) started by @EffortlessSteven*